### PR TITLE
feat: setup automated releases with release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,79 @@
+name: release-please
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Create PR with dist
+        uses: googleapis/code-suggester@v4
+        with:
+          command: pr
+          upstream_repo: readme-engine
+          upstream_owner: thisisrick25
+          description: Build dist
+          title: "chore: build dist"
+          message: "chore: build dist"
+          labels: automated pr
+          branch: build-dist
+          force: true
+          git_dir: .
+          fork: false
+        env:
+          ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  release-please:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          release-type: node
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.releases_created }}
+
+      - name: Tag major and minor versions
+        run: |
+          git config user.name thisisrick25[bot]
+          git config user.email 229200791+thisisrick25[bot]@users.noreply.github.com
+          git remote add gh-token "https://${{ secrets.GITHUB_TOKEN}}@github.com/googleapis/release-please-action.git"
+          git tag -d v${{ steps.release.outputs.major }} || true
+          git tag -d v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
+          git push origin :v${{ steps.release.outputs.major }} || true
+          git push origin :v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
+          git tag -a v${{ steps.release.outputs.major }} -m "Release v${{ steps.release.outputs.major }}"
+          git tag -a v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} -m "Release v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}"
+          git push origin v${{ steps.release.outputs.major }}
+          git push origin v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}
+        if: ${{ steps.release.outputs.releases_created }}


### PR DESCRIPTION
closes #1 

This issue tracks the implementation of automated releases for the project using Release Please.

**Goals:**
- Automate changelog generation.
- Automate version bumping (Semantic Versioning).
- Automate GitHub Release creation.
- Ensure `dist` folder is committed with each release tag.

**Steps:**
1.  Add `release-please-config.json` to the repository root.
2.  Create `.github/workflows/release-please.yml` workflow.
3.  Adopt Conventional Commits for all future commit messages.
4.  (Optional) Configure a Personal Access Token (PAT) if CI checks are needed on Release Please PRs or `release.created` events.

This will streamline the release process and improve project maintainability.