### PR TITLE
feat(wakatime): add WakaTime coding stats plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Next, add the placeholder comments to your `README.md` file where you want the c
 | :----------------------------------------------------------- | :----------------------------------------------------------------------------- |
 | [`notable-contributions`](src/plugins/notable-contributions) | Displays your most recent merged pull requests to repositories you do not own. |
 | [`prs`](src/plugins/prs)                                     | Fetches and displays your latest merged Pull Requests.                         |
+| [`wakatime`](src/plugins/wakatime)                           | Displays your WakaTime coding activity (languages, editors, total time) over the last 30 days. |
 
 ## Configuration
 
@@ -93,6 +94,22 @@ This configuration will:
 
 - Show up to 8 pull requests for the `prs` plugin.
 - Show up to 4 pull requests for the `notable-contributions` plugin.
+
+### WakaTime API Key
+
+The [`wakatime`](src/plugins/wakatime) plugin requires a WakaTime API key. For security, this is provided via the `WAKATIME_API_KEY` environment variable rather than `PLUGIN_CONFIG`. Add your key from [wakatime.com/settings/api-key](https://wakatime.com/settings/api-key) as a repository secret named `WAKATIME_API_KEY`, then pass it to the step:
+
+```yaml
+- name: Update README
+  uses: thisisrick25/readme-engine@v2
+  env:
+    WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
+  with:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    PLUGINS: prs, notable-contributions, wakatime
+```
+
+See the [WakaTime plugin README](src/plugins/wakatime) for full setup instructions.
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "github-action",
       "version": "2.4.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.1"

--- a/src/plugins/wakatime/README.md
+++ b/src/plugins/wakatime/README.md
@@ -1,0 +1,69 @@
+# WakaTime Plugin
+
+This plugin fetches and displays your coding activity from [WakaTime](https://wakatime.com) over the last 30 days, including a summary of total time, top programming languages, and top editors.
+
+## Prerequisites
+
+You need a WakaTime account and its API key:
+
+1. Sign up at [wakatime.com](https://wakatime.com) and install the WakaTime plugin in your editor(s).
+2. Copy your API key from [wakatime.com/settings/api-key](https://wakatime.com/settings/api-key).
+3. Add it as a repository secret named `WAKATIME_API_KEY` in the repository where this action runs (**Settings → Secrets and variables → Actions → New repository secret**).
+
+## Usage
+
+To enable this plugin, include `wakatime` in the `PLUGINS` input and pass the API key to the step via the `WAKATIME_API_KEY` environment variable:
+
+```yaml
+- name: Update README with readme-engine
+  uses: thisisrick25/readme-engine@v2
+  env:
+    WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
+  with:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    PLUGINS: wakatime
+```
+
+The API key is read from the environment (`process.env.WAKATIME_API_KEY`) and is intentionally **not** part of `PLUGIN_CONFIG`, keeping the secret out of the README output and config JSON.
+
+## Placeholder
+
+Add the following placeholder comments to your target Markdown file where you want the stats injected:
+
+```markdown
+<!-- WAKATIME:START -->
+<!-- WAKATIME:END -->
+```
+
+The content between these comments is automatically replaced by the generated WakaTime stats block.
+
+## Example Output
+
+```markdown
+<!-- WAKATIME:START -->
+### WakaTime (Last 30 Days)
+
+**Total:** 42 hrs 18 mins • **Daily average:** 1 hr 24 mins
+
+**Languages**
+
+​```text
+TypeScript  ██████████░░░░░░░░░░   48.2%  20 hrs 24 mins
+Python      █████░░░░░░░░░░░░░░░░   24.1%  10 hrs 12 mins
+Markdown    ██░░░░░░░░░░░░░░░░░░░   11.0%  4 hrs 39 mins
+​```
+
+**Editors**
+
+​```text
+VS Code     ████████████████░░░░   82.5%  34 hrs 54 mins
+Neovim      ███░░░░░░░░░░░░░░░░░░   17.5%  7 hrs 24 mins
+​```
+<!-- WAKATIME:END -->
+```
+
+## Configuration
+
+This plugin does not require `PLUGIN_CONFIG`. It optionally honors a `maxPrs`-style top-N limit (defaults to `5`) for how many languages and editors are shown, but the recommended setup needs no configuration.
+
+The WakaTime API key **must** be provided via the `WAKATIME_API_KEY` environment variable, not `PLUGIN_CONFIG`.

--- a/src/plugins/wakatime/index.ts
+++ b/src/plugins/wakatime/index.ts
@@ -1,0 +1,102 @@
+import type { Plugin } from '../../types.js';
+
+interface WakaTimeStatItem {
+    name: string;
+    percent: number;
+    text: string;
+}
+
+interface WakaTimeStatsData {
+    human_readable_total?: string;
+    human_readable_daily_average?: string;
+    languages?: WakaTimeStatItem[];
+    editors?: WakaTimeStatItem[];
+}
+
+interface WakaTimeStatsResponse {
+    data?: WakaTimeStatsData;
+}
+
+const BAR_LENGTH = 20;
+
+function makeBar(percent: number): string {
+    const filled = Math.round((percent / 100) * BAR_LENGTH);
+    const safeFilled = Math.max(0, Math.min(BAR_LENGTH, filled));
+    return '█'.repeat(safeFilled) + '░'.repeat(BAR_LENGTH - safeFilled);
+}
+
+function renderSection(title: string, items: WakaTimeStatItem[], topN: number): string {
+    const top = items.slice(0, topN);
+    if (top.length === 0) {
+        return '';
+    }
+    const maxNameLength = Math.max(...top.map(item => item.name.length));
+    const lines = top.map(item => {
+        const name = item.name.padEnd(maxNameLength, ' ');
+        const bar = makeBar(item.percent);
+        const percent = `${item.percent.toFixed(1)}%`.padStart(6, ' ');
+        return `${name}  ${bar}  ${percent}  ${item.text}`;
+    });
+    return `**${title}**\n\n\`\`\`text\n${lines.join('\n')}\n\`\`\`\n`;
+}
+
+const wakatimePlugin: Plugin = async (_octokit, _username, config) => {
+    const heading = '### WakaTime (Last 30 Days)\n\n';
+
+    const apiKey = process.env.WAKATIME_API_KEY;
+    if (!apiKey) {
+        return `${heading}WakaTime stats are unavailable because the \`WAKATIME_API_KEY\` secret is not set.`;
+    }
+
+    const topN = parseInt(String((config as { maxPrs?: number }).maxPrs ?? 5), 10);
+
+    try {
+        const encodedKey = Buffer.from(apiKey).toString('base64');
+        const response = await fetch(
+            'https://wakatime.com/api/v1/users/current/stats/last_30_days',
+            {
+                headers: {
+                    Authorization: `Basic ${encodedKey}`,
+                },
+            }
+        );
+
+        if (!response.ok) {
+            return `${heading}Could not fetch WakaTime stats (HTTP ${response.status}).`;
+        }
+
+        const payload = (await response.json()) as WakaTimeStatsResponse;
+        const data = payload.data;
+
+        if (!data) {
+            return `${heading}No WakaTime data available yet.`;
+        }
+
+        const parts: string[] = [];
+
+        if (data.human_readable_total) {
+            parts.push(`**Total:** ${data.human_readable_total}`);
+        }
+        if (data.human_readable_daily_average) {
+            parts.push(`**Daily average:** ${data.human_readable_daily_average}`);
+        }
+
+        let body = parts.length > 0 ? `${parts.join(' • ')}\n\n` : '';
+
+        const languagesSection = renderSection('Languages', data.languages ?? [], topN);
+        const editorsSection = renderSection('Editors', data.editors ?? [], topN);
+
+        body += [languagesSection, editorsSection].filter(Boolean).join('\n');
+
+        if (!body.trim()) {
+            return `${heading}No WakaTime activity recorded in the last 30 days.`;
+        }
+
+        return `${heading}${body.trimEnd()}`;
+    } catch (error) {
+        console.error('Error fetching WakaTime stats:', error);
+        return `${heading}An error occurred while fetching WakaTime stats.`;
+    }
+};
+
+export default wakatimePlugin;


### PR DESCRIPTION
## Summary

Adds a new wakatime plugin that renders your WakaTime coding activity (languages, editors, and total time) over the last 30 days into the README.

## What's included

- **src/plugins/wakatime/index.ts** — Plugin implementation. Reads \WAKATIME_API_KEY\ from the environment, fetches \GET /api/v1/users/current/stats/last_30_days\, and renders a summary line (total + daily average) plus top languages and editors as text bars.
- **src/plugins/wakatime/README.md** — Plugin docs (prerequisites, usage, markers, example output).
- **README.md** — Added \wakatime\ to the Plugins table and a WakaTime API key configuration section.

## Behavior notes

- The API key is passed via \env: WAKATIME_API_KEY\ on the workflow step (kept out of \PLUGIN_CONFIG\).
- Missing key / non-OK response / no activity are all handled gracefully (returns a message, never throws).
- Output is wrapped between \<!-- WAKATIME:START -->\ / \<!-- WAKATIME:END -->\ markers (auto-derived by core).

## Notes

- No \dist/\ changes — compiled output is regenerated by the release workflow after merge.
- \
px tsc --noEmit\ passes with zero errors against the strict tsconfig.