### PR TITLE
feat(author): support commit author attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ Next, add the placeholder comments to your `README.md` file where you want the c
 
 | Input Name      | Description                                                                   | Required |
 | :-------------- | :---------------------------------------------------------------------------- | :------- |
-| `GITHUB_TOKEN`  | The GitHub token to use for authentication.                                   | `true`   |
-| `PLUGINS`       | A comma-separated list of plugins to run.                                     | `true`   |
-| `PLUGIN_CONFIG` | An optional JSON string for providing specific configurations to each plugin. | `false`  |
+| `GITHUB_TOKEN`        | The GitHub token to use for authentication.                                                                                                       | `true`   |
+| `PLUGINS`             | A comma-separated list of plugins to run.                                                                                                         | `true`   |
+| `PLUGIN_CONFIG`       | An optional JSON string for providing specific configurations to each plugin.                                                                     | `false`  |
+| `COMMIT_AUTHOR_NAME`  | Optional. Name to attribute the automated commit to. Must be set together with `COMMIT_AUTHOR_EMAIL`, otherwise the commit is made by the token identity (`github-actions[bot]`). | `false`  |
+| `COMMIT_AUTHOR_EMAIL` | Optional. Email to attribute the automated commit to. Must be verified on the target GitHub account to link the commit and count contributions. Must be set together with `COMMIT_AUTHOR_NAME`. | `false`  |
 
 ### Plugins
 
@@ -110,6 +112,22 @@ The [`wakatime`](src/plugins/wakatime) plugin requires a WakaTime API key. For s
 ```
 
 See the [WakaTime plugin README](src/plugins/wakatime) for full setup instructions.
+
+### Commit Author Attribution
+
+By default the automated README commit is authored by the token identity (`github-actions[bot]`). To attribute it to your own account instead, set both `COMMIT_AUTHOR_NAME` and `COMMIT_AUTHOR_EMAIL`:
+
+```yaml
+- name: Update README
+  uses: thisisrick25/readme-engine@v2
+  with:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    PLUGINS: prs, notable-contributions
+    COMMIT_AUTHOR_NAME: your-username
+    COMMIT_AUTHOR_EMAIL: your-verified-email@example.com
+```
+
+Both inputs are required together. The email must be verified on your GitHub account for the commit to link to your profile and count toward your contribution graph. No personal access token is needed — the default `GITHUB_TOKEN` still authorizes the request.
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,12 @@ inputs:
     description: 'JSON string containing configuration for each plugin (e.g., {"prs": {"maxPrs": 5}, "notable-contributions": {"maxPrs": 10}}).'
     required: false
     default: "{}"
+  COMMIT_AUTHOR_NAME:
+    description: "Optional. The name to attribute the automated commit to. Must be set together with COMMIT_AUTHOR_EMAIL; otherwise the commit is made by the default token identity (github-actions[bot])."
+    required: false
+  COMMIT_AUTHOR_EMAIL:
+    description: "Optional. The email to attribute the automated commit to. Must be verified on the target GitHub account for the commit to link to the user and count toward contributions. Must be set together with COMMIT_AUTHOR_NAME."
+    required: false
 runs:
   using: "node20"
   main: "dist/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,9 @@ async function run(): Promise<string> {
     const pluginConfig: PluginsConfig = JSON.parse(pluginConfigString || '{}');
     console.log(pluginConfig);
 
+    const commitAuthorName = core.getInput('COMMIT_AUTHOR_NAME');
+    const commitAuthorEmail = core.getInput('COMMIT_AUTHOR_EMAIL');
+
     const octokit = github.getOctokit(githubToken);
 
     // Determine source of README content based on mode
@@ -62,14 +65,28 @@ async function run(): Promise<string> {
       console.log('Local output written to tests/local-output.md.');
     } else {
       if (newReadmeContent !== readmeContent && readmeSha) {
-          await octokit.rest.repos.createOrUpdateFileContents({
+          const commitParams = {
               owner: github.context.repo.owner,
               repo: github.context.repo.repo,
               path: 'README.md',
               message: 'docs: update README with metrics',
               content: Buffer.from(newReadmeContent, 'utf-8').toString('base64'),
               sha: readmeSha // Use stored SHA for remote update
-          });
+          };
+
+          // If a custom author is fully specified, attribute the commit to that
+          // identity (both author and committer must be set, otherwise the
+          // committer defaults to the token identity, i.e. github-actions[bot]).
+          if (commitAuthorName && commitAuthorEmail) {
+              const identity = { name: commitAuthorName, email: commitAuthorEmail };
+              await octokit.rest.repos.createOrUpdateFileContents({
+                  ...commitParams,
+                  author: identity,
+                  committer: identity
+              });
+          } else {
+              await octokit.rest.repos.createOrUpdateFileContents(commitParams);
+          }
           console.log('Updated README with metrics on GitHub.');
       } else {
           console.log('No changes to README needed on GitHub.');


### PR DESCRIPTION
## Summary

Adds optional commit-author attribution so the automated README commit can be attributed to a real user instead of `github-actions[bot]`.

## Changes

- **`action.yml`**: two new optional inputs `COMMIT_AUTHOR_NAME` and `COMMIT_AUTHOR_EMAIL` (neither required, no default).
- **`src/index.ts`**: reads the two inputs; when **both** are set, passes `author` **and** `committer` `{ name, email }` to `createOrUpdateFileContents`. When either is omitted, behavior is unchanged (commit made by the default token identity).
- **`README.md`**: documents the two inputs in the Inputs table and adds a **Commit Author Attribution** section with a usage example.

## Behavior notes

- Backward compatible: omitting the inputs preserves the current `github-actions[bot]` behavior.
- Both inputs must be set together. If only the name is set, the committer would default to the token identity, producing a mixed attribution.
- Still uses the default `secrets.GITHUB_TOKEN` \u2014 no PAT required. Attribution is email-based; the author email must be verified on the target account for linking and contribution-graph credit.

## Verification

- `npm run build` (ncc) \u2014 succeeded.
- `npx tsc --noEmit` \u2014 zero errors (satisfies strict tsconfig).
- `dist/` intentionally not committed (managed by the release workflow).