### PR TITLE
feat(wakatime): render all free-tier endpoints in combined block

### DIFF
--- a/src/plugins/wakatime/README.md
+++ b/src/plugins/wakatime/README.md
@@ -1,13 +1,17 @@
 # WakaTime Plugin
 
-This plugin fetches and displays your coding activity from [WakaTime](https://wakatime.com) as a single combined block, pulling from every WakaTime endpoint that is accessible on the free tier:
+This plugin fetches and displays your coding activity from [WakaTime](https://wakatime.com) as a single combined block. You choose which sections to render via the `sections` config option. Each section maps to WakaTime endpoints that are accessible on the free tier:
 
-- **All-Time Total** — lifetime total coding time (`all_time_since_today`).
-- **Last 30 Days** — total, daily average, top languages, and top editors with percentages (`stats/last_30_days`).
-- **All Time** — lifetime top languages and editors with percentages (`stats/all_time`).
-- **Last Year Insights** — rolling one-year top languages and editors (`insights/languages/last_year`, `insights/editors/last_year`). The `insights/*` endpoints only return data for the `last_year` range on the free tier and expose raw seconds only, so percentages are computed by the plugin.
+| Section key  | Renders                                                                                                                                     |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `last30`     | **Last 30 Days** — total, daily average, top languages, and top editors with percentages (`stats/last_30_days`).                            |
+| `allTime`    | **All Time** — lifetime top languages and editors with percentages (`stats/all_time`).                                                      |
+| `sinceToday` | **All-Time Total** — a single lifetime total coding time headline (`all_time_since_today`).                                                  |
+| `insights`   | **Last Year Insights** — rolling one-year top languages and editors (`insights/languages/last_year`, `insights/editors/last_year`).         |
 
-Each section degrades gracefully: if any endpoint is unavailable (for example, `insights/*` on shorter ranges requires a paid plan), that section is simply omitted and the rest still render.
+> The `insights/*` endpoints only return data for the `last_year` range on the free tier and expose raw seconds only, so percentages are computed by the plugin.
+
+Sections render in the order you list them. Each section also degrades gracefully: if an endpoint is unavailable (for example, `insights/*` on shorter ranges requires a paid plan), that section is simply omitted and the rest still render.
 
 ## Prerequisites
 
@@ -93,6 +97,26 @@ Python      ████░░░░░░░░░░░░░░░░   18.3%
 
 ## Configuration
 
-This plugin does not require `PLUGIN_CONFIG`. It optionally honors a `maxPrs`-style top-N limit (defaults to `5`) for how many languages and editors are shown, but the recommended setup needs no configuration.
+Configure which sections to display via the `wakatime.sections` key in `PLUGIN_CONFIG`. It accepts an array of section keys (`last30`, `allTime`, `sinceToday`, `insights`). Sections render in the order given, and duplicates are ignored.
+
+**If `sections` is omitted, only `last30` is rendered** (the default), preserving the original single-block behavior.
+
+```yaml
+- name: Update README with readme-engine
+  uses: thisisrick25/readme-engine@v2
+  env:
+    WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
+  with:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    PLUGINS: wakatime
+    PLUGIN_CONFIG: |
+      {
+        "wakatime": {
+          "sections": ["last30", "allTime", "sinceToday", "insights"]
+        }
+      }
+```
+
+The number of languages and editors shown in each breakdown defaults to `5`.
 
 The WakaTime API key **must** be provided via the `WAKATIME_API_KEY` environment variable, not `PLUGIN_CONFIG`.

--- a/src/plugins/wakatime/README.md
+++ b/src/plugins/wakatime/README.md
@@ -1,6 +1,13 @@
 # WakaTime Plugin
 
-This plugin fetches and displays your coding activity from [WakaTime](https://wakatime.com) over the last 30 days, including a summary of total time, top programming languages, and top editors.
+This plugin fetches and displays your coding activity from [WakaTime](https://wakatime.com) as a single combined block, pulling from every WakaTime endpoint that is accessible on the free tier:
+
+- **All-Time Total** — lifetime total coding time (`all_time_since_today`).
+- **Last 30 Days** — total, daily average, top languages, and top editors with percentages (`stats/last_30_days`).
+- **All Time** — lifetime top languages and editors with percentages (`stats/all_time`).
+- **Last Year Insights** — rolling one-year top languages and editors (`insights/languages/last_year`, `insights/editors/last_year`). The `insights/*` endpoints only return data for the `last_year` range on the free tier and expose raw seconds only, so percentages are computed by the plugin.
+
+Each section degrades gracefully: if any endpoint is unavailable (for example, `insights/*` on shorter ranges requires a paid plan), that section is simply omitted and the rest still render.
 
 ## Prerequisites
 
@@ -41,23 +48,45 @@ The content between these comments is automatically replaced by the generated Wa
 
 ```markdown
 <!-- WAKATIME:START -->
-### WakaTime (Last 30 Days)
+### WakaTime
+
+**All-Time Total:** 2,264 hrs 20 mins (since Thu Sep 3rd 2020)
+
+#### Last 30 Days
 
 **Total:** 42 hrs 18 mins • **Daily average:** 1 hr 24 mins
 
-**Languages**
+_Languages_
 
 ​```text
 TypeScript  ██████████░░░░░░░░░░   48.2%  20 hrs 24 mins
 Python      █████░░░░░░░░░░░░░░░░   24.1%  10 hrs 12 mins
-Markdown    ██░░░░░░░░░░░░░░░░░░░   11.0%  4 hrs 39 mins
 ​```
 
-**Editors**
+_Editors_
 
 ​```text
 VS Code     ████████████████░░░░   82.5%  34 hrs 54 mins
-Neovim      ███░░░░░░░░░░░░░░░░░░   17.5%  7 hrs 24 mins
+​```
+
+#### All Time
+
+**Total:** 1,304 hrs 51 mins
+
+_Languages_
+
+​```text
+Other       ████████░░░░░░░░░░░░   42.4%  552 hrs 45 mins
+TypeScript  ███░░░░░░░░░░░░░░░░░░   16.6%  216 hrs 42 mins
+​```
+
+#### Last Year Insights
+
+_Languages_
+
+​```text
+TypeScript  ████████░░░░░░░░░░░░   40.1%  161h 25m
+Python      ████░░░░░░░░░░░░░░░░   18.3%  73h 40m
 ​```
 <!-- WAKATIME:END -->
 ```

--- a/src/plugins/wakatime/index.ts
+++ b/src/plugins/wakatime/index.ts
@@ -1,5 +1,7 @@
 import type { Plugin } from '../../types.js';
 
+// --- Stats resource shapes (stats/:range) -------------------------------
+
 interface WakaTimeStatItem {
     name: string;
     percent: number;
@@ -17,7 +19,37 @@ interface WakaTimeStatsResponse {
     data?: WakaTimeStatsData;
 }
 
+// --- All-time-since-today shape (total only) ----------------------------
+
+interface WakaTimeAllTimeData {
+    text?: string;
+    range?: { start_text?: string };
+}
+
+interface WakaTimeAllTimeResponse {
+    data?: WakaTimeAllTimeData;
+}
+
+// --- Insights resource shapes (insights/:type/last_year) ----------------
+// Insight items have NO percent/text; only name + seconds + AI/manual split.
+
+interface WakaTimeInsightItem {
+    name: string;
+    total_seconds: number;
+}
+
+interface WakaTimeInsightData {
+    languages?: WakaTimeInsightItem[];
+    editors?: WakaTimeInsightItem[];
+    human_readable_range?: string;
+}
+
+interface WakaTimeInsightResponse {
+    data?: WakaTimeInsightData;
+}
+
 const BAR_LENGTH = 20;
+const BASE_URL = 'https://wakatime.com/api/v1/users/current';
 
 function makeBar(percent: number): string {
     const filled = Math.round((percent / 100) * BAR_LENGTH);
@@ -25,7 +57,35 @@ function makeBar(percent: number): string {
     return '█'.repeat(safeFilled) + '░'.repeat(BAR_LENGTH - safeFilled);
 }
 
-function renderSection(title: string, items: WakaTimeStatItem[], topN: number): string {
+// Turn a raw second count into a compact "Xh Ym" human string, since the
+// insights endpoint (unlike stats) does not provide a human-readable text field.
+function humanizeSeconds(totalSeconds: number): string {
+    const totalMinutes = Math.round(totalSeconds / 60);
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    if (hours > 0) {
+        return `${hours}h ${minutes}m`;
+    }
+    return `${minutes}m`;
+}
+
+async function fetchJson<T>(path: string, authHeader: string): Promise<T | null> {
+    try {
+        const response = await fetch(`${BASE_URL}${path}`, {
+            headers: { Authorization: authHeader },
+        });
+        if (!response.ok) {
+            return null;
+        }
+        return (await response.json()) as T;
+    } catch (error) {
+        console.error(`Error fetching WakaTime endpoint ${path}:`, error);
+        return null;
+    }
+}
+
+// Renders top-N items that already carry percent + text (stats resource).
+function renderStatItems(items: WakaTimeStatItem[], topN: number): string {
     const top = items.slice(0, topN);
     if (top.length === 0) {
         return '';
@@ -37,11 +97,33 @@ function renderSection(title: string, items: WakaTimeStatItem[], topN: number): 
         const percent = `${item.percent.toFixed(1)}%`.padStart(6, ' ');
         return `${name}  ${bar}  ${percent}  ${item.text}`;
     });
-    return `**${title}**\n\n\`\`\`text\n${lines.join('\n')}\n\`\`\`\n`;
+    return `\`\`\`text\n${lines.join('\n')}\n\`\`\`\n`;
+}
+
+// Renders top-N insight items, computing percent from the summed seconds
+// because insight items expose only name + total_seconds.
+function renderInsightItems(items: WakaTimeInsightItem[], topN: number): string {
+    if (items.length === 0) {
+        return '';
+    }
+    const totalSeconds = items.reduce((sum, item) => sum + item.total_seconds, 0);
+    if (totalSeconds <= 0) {
+        return '';
+    }
+    const top = items.slice(0, topN);
+    const maxNameLength = Math.max(...top.map(item => item.name.length));
+    const lines = top.map(item => {
+        const percentValue = (item.total_seconds / totalSeconds) * 100;
+        const name = item.name.padEnd(maxNameLength, ' ');
+        const bar = makeBar(percentValue);
+        const percent = `${percentValue.toFixed(1)}%`.padStart(6, ' ');
+        return `${name}  ${bar}  ${percent}  ${humanizeSeconds(item.total_seconds)}`;
+    });
+    return `\`\`\`text\n${lines.join('\n')}\n\`\`\`\n`;
 }
 
 const wakatimePlugin: Plugin = async (_octokit, _username, config) => {
-    const heading = '### WakaTime (Last 30 Days)\n\n';
+    const heading = '### WakaTime\n\n';
 
     const apiKey = process.env.WAKATIME_API_KEY;
     if (!apiKey) {
@@ -49,50 +131,88 @@ const wakatimePlugin: Plugin = async (_octokit, _username, config) => {
     }
 
     const topN = parseInt(String((config as { maxPrs?: number }).maxPrs ?? 5), 10);
+    const authHeader = `Basic ${Buffer.from(apiKey).toString('base64')}`;
 
     try {
-        const encodedKey = Buffer.from(apiKey).toString('base64');
-        const response = await fetch(
-            'https://wakatime.com/api/v1/users/current/stats/last_30_days',
-            {
-                headers: {
-                    Authorization: `Basic ${encodedKey}`,
-                },
-            }
-        );
+        // Fetch every free-tier endpoint in parallel; each resolves to null on failure
+        // so one paid/errored endpoint never blocks the rest of the block.
+        const [last30, allTime, sinceToday, insightLangs, insightEditors] = await Promise.all([
+            fetchJson<WakaTimeStatsResponse>('/stats/last_30_days', authHeader),
+            fetchJson<WakaTimeStatsResponse>('/stats/all_time', authHeader),
+            fetchJson<WakaTimeAllTimeResponse>('/all_time_since_today', authHeader),
+            fetchJson<WakaTimeInsightResponse>('/insights/languages/last_year', authHeader),
+            fetchJson<WakaTimeInsightResponse>('/insights/editors/last_year', authHeader),
+        ]);
 
-        if (!response.ok) {
-            return `${heading}Could not fetch WakaTime stats (HTTP ${response.status}).`;
+        const sections: string[] = [];
+
+        // Lifetime total line (all_time_since_today) — a single headline number.
+        const sinceData = sinceToday?.data;
+        if (sinceData?.text) {
+            const since = sinceData.range?.start_text
+                ? ` (since ${sinceData.range.start_text})`
+                : '';
+            sections.push(`**All-Time Total:** ${sinceData.text}${since}`);
         }
 
-        const payload = (await response.json()) as WakaTimeStatsResponse;
-        const data = payload.data;
+        // Last 30 days (stats) — total + daily average summary, then breakdowns.
+        const last30Data = last30?.data;
+        if (last30Data) {
+            const summary: string[] = [];
+            if (last30Data.human_readable_total) {
+                summary.push(`**Total:** ${last30Data.human_readable_total}`);
+            }
+            if (last30Data.human_readable_daily_average) {
+                summary.push(`**Daily average:** ${last30Data.human_readable_daily_average}`);
+            }
+            const langs = renderStatItems(last30Data.languages ?? [], topN);
+            const editors = renderStatItems(last30Data.editors ?? [], topN);
+            const block = [
+                summary.length > 0 ? summary.join(' • ') : '',
+                langs ? `_Languages_\n\n${langs}` : '',
+                editors ? `_Editors_\n\n${editors}` : '',
+            ].filter(Boolean).join('\n\n');
+            if (block) {
+                sections.push(`#### Last 30 Days\n\n${block}`);
+            }
+        }
 
-        if (!data) {
+        // All time (stats) — lifetime language/editor breakdown with percent.
+        const allTimeData = allTime?.data;
+        if (allTimeData) {
+            const summary = allTimeData.human_readable_total
+                ? `**Total:** ${allTimeData.human_readable_total}`
+                : '';
+            const langs = renderStatItems(allTimeData.languages ?? [], topN);
+            const editors = renderStatItems(allTimeData.editors ?? [], topN);
+            const block = [
+                summary,
+                langs ? `_Languages_\n\n${langs}` : '',
+                editors ? `_Editors_\n\n${editors}` : '',
+            ].filter(Boolean).join('\n\n');
+            if (block) {
+                sections.push(`#### All Time\n\n${block}`);
+            }
+        }
+
+        // Last year insights — rolling 1-year breakdown (percent computed from seconds).
+        const insightLangItems = insightLangs?.data?.languages ?? [];
+        const insightEditorItems = insightEditors?.data?.editors ?? [];
+        const insightLangBlock = renderInsightItems(insightLangItems, topN);
+        const insightEditorBlock = renderInsightItems(insightEditorItems, topN);
+        if (insightLangBlock || insightEditorBlock) {
+            const block = [
+                insightLangBlock ? `_Languages_\n\n${insightLangBlock}` : '',
+                insightEditorBlock ? `_Editors_\n\n${insightEditorBlock}` : '',
+            ].filter(Boolean).join('\n\n');
+            sections.push(`#### Last Year Insights\n\n${block}`);
+        }
+
+        if (sections.length === 0) {
             return `${heading}No WakaTime data available yet.`;
         }
 
-        const parts: string[] = [];
-
-        if (data.human_readable_total) {
-            parts.push(`**Total:** ${data.human_readable_total}`);
-        }
-        if (data.human_readable_daily_average) {
-            parts.push(`**Daily average:** ${data.human_readable_daily_average}`);
-        }
-
-        let body = parts.length > 0 ? `${parts.join(' • ')}\n\n` : '';
-
-        const languagesSection = renderSection('Languages', data.languages ?? [], topN);
-        const editorsSection = renderSection('Editors', data.editors ?? [], topN);
-
-        body += [languagesSection, editorsSection].filter(Boolean).join('\n');
-
-        if (!body.trim()) {
-            return `${heading}No WakaTime activity recorded in the last 30 days.`;
-        }
-
-        return `${heading}${body.trimEnd()}`;
+        return `${heading}${sections.join('\n\n').trimEnd()}`;
     } catch (error) {
         console.error('Error fetching WakaTime stats:', error);
         return `${heading}An error occurred while fetching WakaTime stats.`;

--- a/src/plugins/wakatime/index.ts
+++ b/src/plugins/wakatime/index.ts
@@ -51,6 +51,24 @@ interface WakaTimeInsightResponse {
 const BAR_LENGTH = 20;
 const BASE_URL = 'https://wakatime.com/api/v1/users/current';
 
+type SectionKey = 'last30' | 'allTime' | 'sinceToday' | 'insights';
+const VALID_SECTIONS: readonly SectionKey[] = ['last30', 'allTime', 'sinceToday', 'insights'];
+const DEFAULT_SECTIONS: readonly SectionKey[] = ['last30'];
+
+function parseSections(config: unknown): SectionKey[] {
+    const raw = (config as { sections?: unknown }).sections;
+    if (!Array.isArray(raw)) {
+        return [...DEFAULT_SECTIONS];
+    }
+    const seen = new Set<SectionKey>();
+    for (const entry of raw) {
+        if (typeof entry === 'string' && (VALID_SECTIONS as readonly string[]).includes(entry)) {
+            seen.add(entry as SectionKey);
+        }
+    }
+    return seen.size > 0 ? [...seen] : [...DEFAULT_SECTIONS];
+}
+
 function makeBar(percent: number): string {
     const filled = Math.round((percent / 100) * BAR_LENGTH);
     const safeFilled = Math.max(0, Math.min(BAR_LENGTH, filled));
@@ -122,6 +140,86 @@ function renderInsightItems(items: WakaTimeInsightItem[], topN: number): string 
     return `\`\`\`text\n${lines.join('\n')}\n\`\`\`\n`;
 }
 
+async function renderLast30(authHeader: string, topN: number): Promise<string> {
+    const response = await fetchJson<WakaTimeStatsResponse>('/stats/last_30_days', authHeader);
+    const data = response?.data;
+    if (!data) {
+        return '';
+    }
+    const summary: string[] = [];
+    if (data.human_readable_total) {
+        summary.push(`**Total:** ${data.human_readable_total}`);
+    }
+    if (data.human_readable_daily_average) {
+        summary.push(`**Daily average:** ${data.human_readable_daily_average}`);
+    }
+    const langs = renderStatItems(data.languages ?? [], topN);
+    const editors = renderStatItems(data.editors ?? [], topN);
+    const block = [
+        summary.length > 0 ? summary.join(' • ') : '',
+        langs ? `_Languages_\n\n${langs}` : '',
+        editors ? `_Editors_\n\n${editors}` : '',
+    ].filter(Boolean).join('\n\n');
+    return block ? `#### Last 30 Days\n\n${block}` : '';
+}
+
+async function renderAllTime(authHeader: string, topN: number): Promise<string> {
+    const response = await fetchJson<WakaTimeStatsResponse>('/stats/all_time', authHeader);
+    const data = response?.data;
+    if (!data) {
+        return '';
+    }
+    const summary = data.human_readable_total ? `**Total:** ${data.human_readable_total}` : '';
+    const langs = renderStatItems(data.languages ?? [], topN);
+    const editors = renderStatItems(data.editors ?? [], topN);
+    const block = [
+        summary,
+        langs ? `_Languages_\n\n${langs}` : '',
+        editors ? `_Editors_\n\n${editors}` : '',
+    ].filter(Boolean).join('\n\n');
+    return block ? `#### All Time\n\n${block}` : '';
+}
+
+async function renderSinceToday(authHeader: string): Promise<string> {
+    const response = await fetchJson<WakaTimeAllTimeResponse>('/all_time_since_today', authHeader);
+    const data = response?.data;
+    if (!data?.text) {
+        return '';
+    }
+    const since = data.range?.start_text ? ` (since ${data.range.start_text})` : '';
+    return `**All-Time Total:** ${data.text}${since}`;
+}
+
+async function renderInsights(authHeader: string, topN: number): Promise<string> {
+    const [langsResponse, editorsResponse] = await Promise.all([
+        fetchJson<WakaTimeInsightResponse>('/insights/languages/last_year', authHeader),
+        fetchJson<WakaTimeInsightResponse>('/insights/editors/last_year', authHeader),
+    ]);
+    const langBlock = renderInsightItems(langsResponse?.data?.languages ?? [], topN);
+    const editorBlock = renderInsightItems(editorsResponse?.data?.editors ?? [], topN);
+    if (!langBlock && !editorBlock) {
+        return '';
+    }
+    const block = [
+        langBlock ? `_Languages_\n\n${langBlock}` : '',
+        editorBlock ? `_Editors_\n\n${editorBlock}` : '',
+    ].filter(Boolean).join('\n\n');
+    return `#### Last Year Insights\n\n${block}`;
+}
+
+async function renderSection(key: SectionKey, authHeader: string, topN: number): Promise<string> {
+    switch (key) {
+        case 'last30':
+            return renderLast30(authHeader, topN);
+        case 'allTime':
+            return renderAllTime(authHeader, topN);
+        case 'sinceToday':
+            return renderSinceToday(authHeader);
+        case 'insights':
+            return renderInsights(authHeader, topN);
+    }
+}
+
 const wakatimePlugin: Plugin = async (_octokit, _username, config) => {
     const heading = '### WakaTime\n\n';
 
@@ -132,81 +230,13 @@ const wakatimePlugin: Plugin = async (_octokit, _username, config) => {
 
     const topN = parseInt(String((config as { maxPrs?: number }).maxPrs ?? 5), 10);
     const authHeader = `Basic ${Buffer.from(apiKey).toString('base64')}`;
+    const selected = parseSections(config);
 
     try {
-        // Fetch every free-tier endpoint in parallel; each resolves to null on failure
-        // so one paid/errored endpoint never blocks the rest of the block.
-        const [last30, allTime, sinceToday, insightLangs, insightEditors] = await Promise.all([
-            fetchJson<WakaTimeStatsResponse>('/stats/last_30_days', authHeader),
-            fetchJson<WakaTimeStatsResponse>('/stats/all_time', authHeader),
-            fetchJson<WakaTimeAllTimeResponse>('/all_time_since_today', authHeader),
-            fetchJson<WakaTimeInsightResponse>('/insights/languages/last_year', authHeader),
-            fetchJson<WakaTimeInsightResponse>('/insights/editors/last_year', authHeader),
-        ]);
-
-        const sections: string[] = [];
-
-        // Lifetime total line (all_time_since_today) — a single headline number.
-        const sinceData = sinceToday?.data;
-        if (sinceData?.text) {
-            const since = sinceData.range?.start_text
-                ? ` (since ${sinceData.range.start_text})`
-                : '';
-            sections.push(`**All-Time Total:** ${sinceData.text}${since}`);
-        }
-
-        // Last 30 days (stats) — total + daily average summary, then breakdowns.
-        const last30Data = last30?.data;
-        if (last30Data) {
-            const summary: string[] = [];
-            if (last30Data.human_readable_total) {
-                summary.push(`**Total:** ${last30Data.human_readable_total}`);
-            }
-            if (last30Data.human_readable_daily_average) {
-                summary.push(`**Daily average:** ${last30Data.human_readable_daily_average}`);
-            }
-            const langs = renderStatItems(last30Data.languages ?? [], topN);
-            const editors = renderStatItems(last30Data.editors ?? [], topN);
-            const block = [
-                summary.length > 0 ? summary.join(' • ') : '',
-                langs ? `_Languages_\n\n${langs}` : '',
-                editors ? `_Editors_\n\n${editors}` : '',
-            ].filter(Boolean).join('\n\n');
-            if (block) {
-                sections.push(`#### Last 30 Days\n\n${block}`);
-            }
-        }
-
-        // All time (stats) — lifetime language/editor breakdown with percent.
-        const allTimeData = allTime?.data;
-        if (allTimeData) {
-            const summary = allTimeData.human_readable_total
-                ? `**Total:** ${allTimeData.human_readable_total}`
-                : '';
-            const langs = renderStatItems(allTimeData.languages ?? [], topN);
-            const editors = renderStatItems(allTimeData.editors ?? [], topN);
-            const block = [
-                summary,
-                langs ? `_Languages_\n\n${langs}` : '',
-                editors ? `_Editors_\n\n${editors}` : '',
-            ].filter(Boolean).join('\n\n');
-            if (block) {
-                sections.push(`#### All Time\n\n${block}`);
-            }
-        }
-
-        // Last year insights — rolling 1-year breakdown (percent computed from seconds).
-        const insightLangItems = insightLangs?.data?.languages ?? [];
-        const insightEditorItems = insightEditors?.data?.editors ?? [];
-        const insightLangBlock = renderInsightItems(insightLangItems, topN);
-        const insightEditorBlock = renderInsightItems(insightEditorItems, topN);
-        if (insightLangBlock || insightEditorBlock) {
-            const block = [
-                insightLangBlock ? `_Languages_\n\n${insightLangBlock}` : '',
-                insightEditorBlock ? `_Editors_\n\n${insightEditorBlock}` : '',
-            ].filter(Boolean).join('\n\n');
-            sections.push(`#### Last Year Insights\n\n${block}`);
-        }
+        const rendered = await Promise.all(
+            selected.map(key => renderSection(key, authHeader, topN)),
+        );
+        const sections = rendered.filter(Boolean);
 
         if (sections.length === 0) {
             return `${heading}No WakaTime data available yet.`;


### PR DESCRIPTION
Expands the WakaTime plugin to render data from all five free-tier (HTTP 200) endpoints in a single combined block:

- `stats/last_30_days` — languages + editors + total + daily average (with percent bars)
- `stats/all_time` — lifetime languages + editors breakdown (with percent bars)
- `all_time_since_today` — lifetime total time header line
- `insights/languages/last_year` — rolling 1-year language breakdown (percent computed from seconds)
- `insights/editors/last_year` — rolling 1-year editor breakdown (percent computed from seconds)

## Details
- Each endpoint is fetched in parallel; a failed/unavailable endpoint resolves to null so it never blocks the others (graceful per-section degradation).
- Handles the two different item shapes: stats items expose percent + text; insights items expose only name + total_seconds (+ AI/manual split), so percent and duration are computed.
- Heading changed from `### WakaTime (Last 30 Days)` to `### WakaTime` with `####` sub-sections.
- Plugin README updated with the new combined-output example.

## Verification
- `npm run build` exit 0
- `npx tsc --noEmit` exit 0 (strict tsconfig)