### PR TITLE
feat(wakatime): split insights into separate language and editor sections

### DIFF
--- a/src/plugins/wakatime/README.md
+++ b/src/plugins/wakatime/README.md
@@ -2,14 +2,15 @@
 
 This plugin fetches and displays your coding activity from [WakaTime](https://wakatime.com) as a single combined block. You choose which sections to render via the `sections` config option. Each section maps to WakaTime endpoints that are accessible on the free tier:
 
-| Section key  | Renders                                                                                                                                     |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `last30`     | **Last 30 Days** — total, daily average, top languages, and top editors with percentages (`stats/last_30_days`).                            |
-| `allTime`    | **All Time** — lifetime top languages and editors with percentages (`stats/all_time`).                                                      |
-| `sinceToday` | **All-Time Total** — a single lifetime total coding time headline (`all_time_since_today`).                                                  |
-| `insights`   | **Last Year Insights** — rolling one-year top languages and editors (`insights/languages/last_year`, `insights/editors/last_year`).         |
+| Section key         | Renders                                                                                                            |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `last30`            | **Last 30 Days** — total, daily average, top languages, and top editors with percentages (`stats/last_30_days`).  |
+| `allTime`           | **All Time** — lifetime top languages and editors with percentages (`stats/all_time`).                            |
+| `sinceToday`        | **All-Time Total** — a single lifetime total coding time headline (`all_time_since_today`).                        |
+| `insightsLanguages` | **Last Year Languages** — rolling one-year top languages (`insights/languages/last_year`).                        |
+| `insightsEditors`   | **Last Year Editors** — rolling one-year top editors (`insights/editors/last_year`).                              |
 
-> The `insights/*` endpoints only return data for the `last_year` range on the free tier and expose raw seconds only, so percentages are computed by the plugin.
+> The `insightsLanguages` and `insightsEditors` endpoints only return data for the `last_year` range on the free tier and expose raw seconds only, so percentages are computed by the plugin.
 
 Sections render in the order you list them. Each section also degrades gracefully: if an endpoint is unavailable (for example, `insights/*` on shorter ranges requires a paid plan), that section is simply omitted and the rest still render.
 
@@ -84,20 +85,24 @@ Other       ████████░░░░░░░░░░░░   42.4%
 TypeScript  ███░░░░░░░░░░░░░░░░░░   16.6%  216 hrs 42 mins
 ​```
 
-#### Last Year Insights
-
-_Languages_
+#### Last Year Languages
 
 ​```text
 TypeScript  ████████░░░░░░░░░░░░   40.1%  161h 25m
 Python      ████░░░░░░░░░░░░░░░░   18.3%  73h 40m
+​```
+
+#### Last Year Editors
+
+​```text
+VS Code     ██████████░░░░░░░░░░   52.9%  213h 10m
 ​```
 <!-- WAKATIME:END -->
 ```
 
 ## Configuration
 
-Configure which sections to display via the `wakatime.sections` key in `PLUGIN_CONFIG`. It accepts an array of section keys (`last30`, `allTime`, `sinceToday`, `insights`). Sections render in the order given, and duplicates are ignored.
+Configure which sections to display via the `wakatime.sections` key in `PLUGIN_CONFIG`. It accepts an array of section keys (`last30`, `allTime`, `sinceToday`, `insightsLanguages`, `insightsEditors`). Sections render in the order given, and duplicates are ignored.
 
 **If `sections` is omitted, only `last30` is rendered** (the default), preserving the original single-block behavior.
 
@@ -112,7 +117,7 @@ Configure which sections to display via the `wakatime.sections` key in `PLUGIN_C
     PLUGIN_CONFIG: |
       {
         "wakatime": {
-          "sections": ["last30", "allTime", "sinceToday", "insights"]
+          "sections": ["last30", "allTime", "sinceToday", "insightsLanguages", "insightsEditors"]
         }
       }
 ```

--- a/src/plugins/wakatime/index.ts
+++ b/src/plugins/wakatime/index.ts
@@ -51,8 +51,8 @@ interface WakaTimeInsightResponse {
 const BAR_LENGTH = 20;
 const BASE_URL = 'https://wakatime.com/api/v1/users/current';
 
-type SectionKey = 'last30' | 'allTime' | 'sinceToday' | 'insights';
-const VALID_SECTIONS: readonly SectionKey[] = ['last30', 'allTime', 'sinceToday', 'insights'];
+type SectionKey = 'last30' | 'allTime' | 'sinceToday' | 'insightsLanguages' | 'insightsEditors';
+const VALID_SECTIONS: readonly SectionKey[] = ['last30', 'allTime', 'sinceToday', 'insightsLanguages', 'insightsEditors'];
 const DEFAULT_SECTIONS: readonly SectionKey[] = ['last30'];
 
 function parseSections(config: unknown): SectionKey[] {
@@ -190,21 +190,16 @@ async function renderSinceToday(authHeader: string): Promise<string> {
     return `**All-Time Total:** ${data.text}${since}`;
 }
 
-async function renderInsights(authHeader: string, topN: number): Promise<string> {
-    const [langsResponse, editorsResponse] = await Promise.all([
-        fetchJson<WakaTimeInsightResponse>('/insights/languages/last_year', authHeader),
-        fetchJson<WakaTimeInsightResponse>('/insights/editors/last_year', authHeader),
-    ]);
-    const langBlock = renderInsightItems(langsResponse?.data?.languages ?? [], topN);
-    const editorBlock = renderInsightItems(editorsResponse?.data?.editors ?? [], topN);
-    if (!langBlock && !editorBlock) {
-        return '';
-    }
-    const block = [
-        langBlock ? `_Languages_\n\n${langBlock}` : '',
-        editorBlock ? `_Editors_\n\n${editorBlock}` : '',
-    ].filter(Boolean).join('\n\n');
-    return `#### Last Year Insights\n\n${block}`;
+async function renderInsightsLanguages(authHeader: string, topN: number): Promise<string> {
+    const response = await fetchJson<WakaTimeInsightResponse>('/insights/languages/last_year', authHeader);
+    const block = renderInsightItems(response?.data?.languages ?? [], topN);
+    return block ? `#### Last Year Languages\n\n${block}` : '';
+}
+
+async function renderInsightsEditors(authHeader: string, topN: number): Promise<string> {
+    const response = await fetchJson<WakaTimeInsightResponse>('/insights/editors/last_year', authHeader);
+    const block = renderInsightItems(response?.data?.editors ?? [], topN);
+    return block ? `#### Last Year Editors\n\n${block}` : '';
 }
 
 async function renderSection(key: SectionKey, authHeader: string, topN: number): Promise<string> {
@@ -215,8 +210,10 @@ async function renderSection(key: SectionKey, authHeader: string, topN: number):
             return renderAllTime(authHeader, topN);
         case 'sinceToday':
             return renderSinceToday(authHeader);
-        case 'insights':
-            return renderInsights(authHeader, topN);
+        case 'insightsLanguages':
+            return renderInsightsLanguages(authHeader, topN);
+        case 'insightsEditors':
+            return renderInsightsEditors(authHeader, topN);
     }
 }
 


### PR DESCRIPTION
Splits the single insights config key into two independent keys for granular control:

- insightsLanguages -> insights/languages/last_year
- insightsEditors -> insights/editors/last_year

The section config now supports 5 keys: last30, allTime, sinceToday, insightsLanguages, insightsEditors. Default remains ['last30'] when sections is unset. Sections render in config order; only selected endpoints are fetched; graceful per-section degradation preserved.

- Updated SectionKey union + VALID_SECTIONS
- Split renderInsights into renderInsightsLanguages (#### Last Year Languages) + renderInsightsEditors (#### Last Year Editors)
- Updated exhaustive renderSection switch
- Updated plugin README sections table, note, example output, and config example
- Verified: npm run build exit 0, npx tsc --noEmit exit 0