### PR TITLE
feat(wakatime): split sections into independent per-facet keys

### DIFF
--- a/src/plugins/wakatime/README.md
+++ b/src/plugins/wakatime/README.md
@@ -2,14 +2,20 @@
 
 This plugin fetches and displays your coding activity from [WakaTime](https://wakatime.com) as a single combined block. You choose which sections to render via the `sections` config option. Each section maps to WakaTime endpoints that are accessible on the free tier:
 
-| Section key         | Renders                                                                                                            |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `last30`            | **Last 30 Days** — total, daily average, top languages, and top editors with percentages (`stats/last_30_days`).  |
-| `allTime`           | **All Time** — lifetime top languages and editors with percentages (`stats/all_time`).                            |
-| `sinceToday`        | **All-Time Total** — a single lifetime total coding time headline (`all_time_since_today`).                        |
-| `insightsLanguages` | **Last Year Languages** — rolling one-year top languages (`insights/languages/last_year`).                        |
-| `insightsEditors`   | **Last Year Editors** — rolling one-year top editors (`insights/editors/last_year`).                              |
+| Section key         | Renders                                                                                              | Endpoint                       |
+| ------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `last30Total`       | **Last 30 Days** — total coding time and daily average headline.                                    | `stats/last_30_days`           |
+| `last30Languages`   | **Last 30 Days — Languages** — top languages with percentages.                                      | `stats/last_30_days`           |
+| `last30Editors`     | **Last 30 Days — Editors** — top editors with percentages.                                          | `stats/last_30_days`           |
+| `allTimeTotal`      | **All Time** — lifetime total coding time headline.                                                 | `stats/all_time`               |
+| `allTimeLanguages`  | **All Time — Languages** — lifetime top languages with percentages.                                 | `stats/all_time`               |
+| `allTimeEditors`    | **All Time — Editors** — lifetime top editors with percentages.                                     | `stats/all_time`               |
+| `sinceToday`        | **All-Time Total** — a single lifetime total coding time headline.                                  | `all_time_since_today`         |
+| `insightsLanguages` | **Last Year Languages** — rolling one-year top languages.                                           | `insights/languages/last_year` |
+| `insightsEditors`   | **Last Year Editors** — rolling one-year top editors.                                               | `insights/editors/last_year`   |
 
+> Each facet is an independent section key. Keys sharing an endpoint (for example `last30Total`, `last30Languages`, `last30Editors`) reuse a single request per run.
+>
 > The `insightsLanguages` and `insightsEditors` endpoints only return data for the `last_year` range on the free tier and expose raw seconds only, so percentages are computed by the plugin.
 
 Sections render in the order you list them. Each section also degrades gracefully: if an endpoint is unavailable (for example, `insights/*` on shorter ranges requires a paid plan), that section is simply omitted and the rest still render.
@@ -61,14 +67,14 @@ The content between these comments is automatically replaced by the generated Wa
 
 **Total:** 42 hrs 18 mins • **Daily average:** 1 hr 24 mins
 
-_Languages_
+#### Last 30 Days — Languages
 
 ​```text
 TypeScript  ██████████░░░░░░░░░░   48.2%  20 hrs 24 mins
 Python      █████░░░░░░░░░░░░░░░░   24.1%  10 hrs 12 mins
 ​```
 
-_Editors_
+#### Last 30 Days — Editors
 
 ​```text
 VS Code     ████████████████░░░░   82.5%  34 hrs 54 mins
@@ -78,7 +84,7 @@ VS Code     ████████████████░░░░   82.5%
 
 **Total:** 1,304 hrs 51 mins
 
-_Languages_
+#### All Time — Languages
 
 ​```text
 Other       ████████░░░░░░░░░░░░   42.4%  552 hrs 45 mins
@@ -102,9 +108,9 @@ VS Code     ██████████░░░░░░░░░░   52.9%
 
 ## Configuration
 
-Configure which sections to display via the `wakatime.sections` key in `PLUGIN_CONFIG`. It accepts an array of section keys (`last30`, `allTime`, `sinceToday`, `insightsLanguages`, `insightsEditors`). Sections render in the order given, and duplicates are ignored.
+Configure which sections to display via the `wakatime.sections` key in `PLUGIN_CONFIG`. It accepts an array of section keys (`last30Total`, `last30Languages`, `last30Editors`, `allTimeTotal`, `allTimeLanguages`, `allTimeEditors`, `sinceToday`, `insightsLanguages`, `insightsEditors`). Sections render in the order given, and duplicates are ignored.
 
-**If `sections` is omitted, only `last30` is rendered** (the default), preserving the original single-block behavior.
+**If `sections` is omitted, only `last30Languages` is rendered** (the default).
 
 ```yaml
 - name: Update README with readme-engine
@@ -117,7 +123,7 @@ Configure which sections to display via the `wakatime.sections` key in `PLUGIN_C
     PLUGIN_CONFIG: |
       {
         "wakatime": {
-          "sections": ["last30", "allTime", "sinceToday", "insightsLanguages", "insightsEditors"]
+          "sections": ["last30Total", "last30Languages", "last30Editors", "allTimeTotal", "allTimeLanguages", "allTimeEditors", "sinceToday", "insightsLanguages", "insightsEditors"]
         }
       }
 ```

--- a/src/plugins/wakatime/index.ts
+++ b/src/plugins/wakatime/index.ts
@@ -51,9 +51,28 @@ interface WakaTimeInsightResponse {
 const BAR_LENGTH = 20;
 const BASE_URL = 'https://wakatime.com/api/v1/users/current';
 
-type SectionKey = 'last30' | 'allTime' | 'sinceToday' | 'insightsLanguages' | 'insightsEditors';
-const VALID_SECTIONS: readonly SectionKey[] = ['last30', 'allTime', 'sinceToday', 'insightsLanguages', 'insightsEditors'];
-const DEFAULT_SECTIONS: readonly SectionKey[] = ['last30'];
+type SectionKey =
+    | 'last30Total'
+    | 'last30Languages'
+    | 'last30Editors'
+    | 'allTimeTotal'
+    | 'allTimeLanguages'
+    | 'allTimeEditors'
+    | 'sinceToday'
+    | 'insightsLanguages'
+    | 'insightsEditors';
+const VALID_SECTIONS: readonly SectionKey[] = [
+    'last30Total',
+    'last30Languages',
+    'last30Editors',
+    'allTimeTotal',
+    'allTimeLanguages',
+    'allTimeEditors',
+    'sinceToday',
+    'insightsLanguages',
+    'insightsEditors',
+];
+const DEFAULT_SECTIONS: readonly SectionKey[] = ['last30Languages'];
 
 function parseSections(config: unknown): SectionKey[] {
     const raw = (config as { sections?: unknown }).sections;
@@ -102,6 +121,23 @@ async function fetchJson<T>(path: string, authHeader: string): Promise<T | null>
     }
 }
 
+// Granular section keys can share an endpoint (e.g. last30Total/Languages/Editors
+// all read /stats/last_30_days), so memoize each path per run to fetch it once.
+function createEndpointCache(authHeader: string): <T>(path: string) => Promise<T | null> {
+    const cache = new Map<string, Promise<unknown>>();
+    return <T>(path: string): Promise<T | null> => {
+        const existing = cache.get(path);
+        if (existing) {
+            return existing as Promise<T | null>;
+        }
+        const pending = fetchJson<T>(path, authHeader);
+        cache.set(path, pending);
+        return pending;
+    };
+}
+
+type EndpointFetch = <T>(path: string) => Promise<T | null>;
+
 // Renders top-N items that already carry percent + text (stats resource).
 function renderStatItems(items: WakaTimeStatItem[], topN: number): string {
     const top = items.slice(0, topN);
@@ -140,9 +176,8 @@ function renderInsightItems(items: WakaTimeInsightItem[], topN: number): string 
     return `\`\`\`text\n${lines.join('\n')}\n\`\`\`\n`;
 }
 
-async function renderLast30(authHeader: string, topN: number): Promise<string> {
-    const response = await fetchJson<WakaTimeStatsResponse>('/stats/last_30_days', authHeader);
-    const data = response?.data;
+async function renderLast30Total(fetchEndpoint: EndpointFetch): Promise<string> {
+    const data = (await fetchEndpoint<WakaTimeStatsResponse>('/stats/last_30_days'))?.data;
     if (!data) {
         return '';
     }
@@ -153,36 +188,43 @@ async function renderLast30(authHeader: string, topN: number): Promise<string> {
     if (data.human_readable_daily_average) {
         summary.push(`**Daily average:** ${data.human_readable_daily_average}`);
     }
-    const langs = renderStatItems(data.languages ?? [], topN);
-    const editors = renderStatItems(data.editors ?? [], topN);
-    const block = [
-        summary.length > 0 ? summary.join(' • ') : '',
-        langs ? `_Languages_\n\n${langs}` : '',
-        editors ? `_Editors_\n\n${editors}` : '',
-    ].filter(Boolean).join('\n\n');
-    return block ? `#### Last 30 Days\n\n${block}` : '';
+    return summary.length > 0 ? `#### Last 30 Days\n\n${summary.join(' • ')}` : '';
 }
 
-async function renderAllTime(authHeader: string, topN: number): Promise<string> {
-    const response = await fetchJson<WakaTimeStatsResponse>('/stats/all_time', authHeader);
-    const data = response?.data;
-    if (!data) {
+async function renderLast30Languages(fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
+    const data = (await fetchEndpoint<WakaTimeStatsResponse>('/stats/last_30_days'))?.data;
+    const block = renderStatItems(data?.languages ?? [], topN);
+    return block ? `#### Last 30 Days — Languages\n\n${block}` : '';
+}
+
+async function renderLast30Editors(fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
+    const data = (await fetchEndpoint<WakaTimeStatsResponse>('/stats/last_30_days'))?.data;
+    const block = renderStatItems(data?.editors ?? [], topN);
+    return block ? `#### Last 30 Days — Editors\n\n${block}` : '';
+}
+
+async function renderAllTimeTotal(fetchEndpoint: EndpointFetch): Promise<string> {
+    const data = (await fetchEndpoint<WakaTimeStatsResponse>('/stats/all_time'))?.data;
+    if (!data?.human_readable_total) {
         return '';
     }
-    const summary = data.human_readable_total ? `**Total:** ${data.human_readable_total}` : '';
-    const langs = renderStatItems(data.languages ?? [], topN);
-    const editors = renderStatItems(data.editors ?? [], topN);
-    const block = [
-        summary,
-        langs ? `_Languages_\n\n${langs}` : '',
-        editors ? `_Editors_\n\n${editors}` : '',
-    ].filter(Boolean).join('\n\n');
-    return block ? `#### All Time\n\n${block}` : '';
+    return `#### All Time\n\n**Total:** ${data.human_readable_total}`;
 }
 
-async function renderSinceToday(authHeader: string): Promise<string> {
-    const response = await fetchJson<WakaTimeAllTimeResponse>('/all_time_since_today', authHeader);
-    const data = response?.data;
+async function renderAllTimeLanguages(fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
+    const data = (await fetchEndpoint<WakaTimeStatsResponse>('/stats/all_time'))?.data;
+    const block = renderStatItems(data?.languages ?? [], topN);
+    return block ? `#### All Time — Languages\n\n${block}` : '';
+}
+
+async function renderAllTimeEditors(fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
+    const data = (await fetchEndpoint<WakaTimeStatsResponse>('/stats/all_time'))?.data;
+    const block = renderStatItems(data?.editors ?? [], topN);
+    return block ? `#### All Time — Editors\n\n${block}` : '';
+}
+
+async function renderSinceToday(fetchEndpoint: EndpointFetch): Promise<string> {
+    const data = (await fetchEndpoint<WakaTimeAllTimeResponse>('/all_time_since_today'))?.data;
     if (!data?.text) {
         return '';
     }
@@ -190,30 +232,38 @@ async function renderSinceToday(authHeader: string): Promise<string> {
     return `**All-Time Total:** ${data.text}${since}`;
 }
 
-async function renderInsightsLanguages(authHeader: string, topN: number): Promise<string> {
-    const response = await fetchJson<WakaTimeInsightResponse>('/insights/languages/last_year', authHeader);
-    const block = renderInsightItems(response?.data?.languages ?? [], topN);
+async function renderInsightsLanguages(fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
+    const data = (await fetchEndpoint<WakaTimeInsightResponse>('/insights/languages/last_year'))?.data;
+    const block = renderInsightItems(data?.languages ?? [], topN);
     return block ? `#### Last Year Languages\n\n${block}` : '';
 }
 
-async function renderInsightsEditors(authHeader: string, topN: number): Promise<string> {
-    const response = await fetchJson<WakaTimeInsightResponse>('/insights/editors/last_year', authHeader);
-    const block = renderInsightItems(response?.data?.editors ?? [], topN);
+async function renderInsightsEditors(fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
+    const data = (await fetchEndpoint<WakaTimeInsightResponse>('/insights/editors/last_year'))?.data;
+    const block = renderInsightItems(data?.editors ?? [], topN);
     return block ? `#### Last Year Editors\n\n${block}` : '';
 }
 
-async function renderSection(key: SectionKey, authHeader: string, topN: number): Promise<string> {
+async function renderSection(key: SectionKey, fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
     switch (key) {
-        case 'last30':
-            return renderLast30(authHeader, topN);
-        case 'allTime':
-            return renderAllTime(authHeader, topN);
+        case 'last30Total':
+            return renderLast30Total(fetchEndpoint);
+        case 'last30Languages':
+            return renderLast30Languages(fetchEndpoint, topN);
+        case 'last30Editors':
+            return renderLast30Editors(fetchEndpoint, topN);
+        case 'allTimeTotal':
+            return renderAllTimeTotal(fetchEndpoint);
+        case 'allTimeLanguages':
+            return renderAllTimeLanguages(fetchEndpoint, topN);
+        case 'allTimeEditors':
+            return renderAllTimeEditors(fetchEndpoint, topN);
         case 'sinceToday':
-            return renderSinceToday(authHeader);
+            return renderSinceToday(fetchEndpoint);
         case 'insightsLanguages':
-            return renderInsightsLanguages(authHeader, topN);
+            return renderInsightsLanguages(fetchEndpoint, topN);
         case 'insightsEditors':
-            return renderInsightsEditors(authHeader, topN);
+            return renderInsightsEditors(fetchEndpoint, topN);
     }
 }
 
@@ -228,10 +278,11 @@ const wakatimePlugin: Plugin = async (_octokit, _username, config) => {
     const topN = parseInt(String((config as { maxPrs?: number }).maxPrs ?? 5), 10);
     const authHeader = `Basic ${Buffer.from(apiKey).toString('base64')}`;
     const selected = parseSections(config);
+    const fetchEndpoint = createEndpointCache(authHeader);
 
     try {
         const rendered = await Promise.all(
-            selected.map(key => renderSection(key, authHeader, topN)),
+            selected.map(key => renderSection(key, fetchEndpoint, topN)),
         );
         const sections = rendered.filter(Boolean);
 


### PR DESCRIPTION
Splits the coupled `last30` and `allTime` WakaTime section keys into fully independent per-facet keys so each Total / Languages / Editors block is toggleable and orderable via `PLUGIN_CONFIG`.

### New section keys (9 total)
- `last30Total` - Last 30 Days total + daily average headline
- `last30Languages` - Last 30 Days top languages
- `last30Editors` - Last 30 Days top editors
- `allTimeTotal` - lifetime total headline
- `allTimeLanguages` - lifetime top languages
- `allTimeEditors` - lifetime top editors
- `sinceToday` - all-time-total one-liner (unchanged)
- `insightsLanguages` - last-year languages (unchanged)
- `insightsEditors` - last-year editors (unchanged)

### Breaking change
The previous bundled `last30` and `allTime` keys are removed (no aliases). `DEFAULT_SECTIONS` is now `['last30Languages']`.

### Implementation notes
- Added a per-run endpoint cache so keys sharing an endpoint (e.g. the three `last30*` keys all read `/stats/last_30_days`) fetch it only once.
- `renderSection` remains an exhaustive switch over the 9 keys (no default).
- Graceful per-section degradation preserved.

### Verification
- `npm run build` exit 0
- `npx tsc --noEmit` exit 0 (strict tsconfig satisfied)