### PR TITLE
feat(wakatime): add time windows, categories, best-day and AI/manual split

### DIFF
--- a/src/plugins/wakatime/README.md
+++ b/src/plugins/wakatime/README.md
@@ -1,24 +1,39 @@
 # WakaTime Plugin
 
-This plugin fetches and displays your coding activity from [WakaTime](https://wakatime.com) as a single combined block. You choose which sections to render via the `sections` config option. Each section maps to WakaTime endpoints that are accessible on the free tier:
+This plugin fetches and displays your coding activity from [WakaTime](https://wakatime.com) as a single combined block. You choose which sections to render via the `sections` config option.
 
-| Section key         | Renders                                                                                              | Endpoint                       |
-| ------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------ |
-| `last30Total`       | **Last 30 Days** — total coding time and daily average headline.                                    | `stats/last_30_days`           |
-| `last30Languages`   | **Last 30 Days — Languages** — top languages with percentages.                                      | `stats/last_30_days`           |
-| `last30Editors`     | **Last 30 Days — Editors** — top editors with percentages.                                          | `stats/last_30_days`           |
-| `allTimeTotal`      | **All Time** — lifetime total coding time headline.                                                 | `stats/all_time`               |
-| `allTimeLanguages`  | **All Time — Languages** — lifetime top languages with percentages.                                 | `stats/all_time`               |
-| `allTimeEditors`    | **All Time — Editors** — lifetime top editors with percentages.                                     | `stats/all_time`               |
-| `sinceToday`        | **All-Time Total** — a single lifetime total coding time headline.                                  | `all_time_since_today`         |
-| `insightsLanguages` | **Last Year Languages** — rolling one-year top languages.                                           | `insights/languages/last_year` |
-| `insightsEditors`   | **Last Year Editors** — rolling one-year top editors.                                               | `insights/editors/last_year`   |
+Each section key is a **time window** (`last7`, `last30`, `allTime`, `lastYear`) combined with a **facet** (`Total`, `Languages`, `Editors`, `Categories`, `BestDay`), giving keys like `last30Languages` or `allTimeCategories`. There is also a standalone `sinceToday` key. Every window reads a `stats/:range` endpoint that is accessible on the free tier.
 
-> Each facet is an independent section key. Keys sharing an endpoint (for example `last30Total`, `last30Languages`, `last30Editors`) reuse a single request per run.
+**Windows** (each reads `stats/<range>`):
+
+| Window     | Range              | Endpoint               |
+| ---------- | ------------------ | ---------------------- |
+| `last7`    | Last 7 days        | `stats/last_7_days`    |
+| `last30`   | Last 30 days       | `stats/last_30_days`   |
+| `allTime`  | Lifetime           | `stats/all_time`       |
+| `lastYear` | Rolling 12 months  | `stats/last_year`      |
+
+**Facets** (append to any window, e.g. `last7Languages`):
+
+| Facet        | Renders                                                                    |
+| ------------ | -------------------------------------------------------------------------- |
+| `Total`      | Total coding time and daily average headline.                              |
+| `Languages`  | Top languages with percentages, bars, and per-item AI/manual split.        |
+| `Editors`    | Top editors with percentages, bars, and per-item AI/manual split.          |
+| `Categories` | Top activity categories (e.g. AI Coding, Writing Docs) with percentages.   |
+| `BestDay`    | The single most productive day in the window.                              |
+
+**Standalone key:**
+
+| Section key  | Renders                                                            | Endpoint               |
+| ------------ | ----------------------------------------------------------------- | ---------------------- |
+| `sinceToday` | **All-Time Total** — a single lifetime total coding time headline. | `all_time_since_today` |
+
+> Each facet is an independent section key. Keys sharing an endpoint (for example `last30Total`, `last30Languages`, `last30Editors` all read `stats/last_30_days`) reuse a single request per run.
 >
-> The `insightsLanguages` and `insightsEditors` endpoints only return data for the `last_year` range on the free tier and expose raw seconds only, so percentages are computed by the plugin.
+> `Languages`, `Editors`, and `Categories` items are annotated inline with their AI-assisted vs. manual coding split (e.g. `[AI 62% · Manual 38%]`) when WakaTime provides those figures.
 
-Sections render in the order you list them. Each section also degrades gracefully: if an endpoint is unavailable (for example, `insights/*` on shorter ranges requires a paid plan), that section is simply omitted and the rest still render.
+Sections render in the order you list them. Each section also degrades gracefully: if an endpoint or facet is unavailable, that section is simply omitted and the rest still render.
 
 ## Prerequisites
 
@@ -70,45 +85,39 @@ The content between these comments is automatically replaced by the generated Wa
 #### Last 30 Days — Languages
 
 ​```text
-TypeScript  ██████████░░░░░░░░░░   48.2%  20 hrs 24 mins
-Python      █████░░░░░░░░░░░░░░░░   24.1%  10 hrs 12 mins
+TypeScript  ██████████░░░░░░░░░░   48.2%  20 hrs 24 mins [AI 61% · Manual 39%]
+Python      █████░░░░░░░░░░░░░░░░   24.1%  10 hrs 12 mins [AI 45% · Manual 55%]
 ​```
 
 #### Last 30 Days — Editors
 
 ​```text
-VS Code     ████████████████░░░░   82.5%  34 hrs 54 mins
+VS Code     ████████████████░░░░   82.5%  34 hrs 54 mins [AI 58% · Manual 42%]
 ​```
 
-#### All Time
-
-**Total:** 1,304 hrs 51 mins
-
-#### All Time — Languages
+#### Last 30 Days — Categories
 
 ​```text
-Other       ████████░░░░░░░░░░░░   42.4%  552 hrs 45 mins
-TypeScript  ███░░░░░░░░░░░░░░░░░░   16.6%  216 hrs 42 mins
+AI Coding   ███████████████░░░░░   73.2%  30 hrs 58 mins
+Coding      ██░░░░░░░░░░░░░░░░░░░   10.3%   4 hrs 21 mins
 ​```
 
-#### Last Year Languages
+#### Last 30 Days — Best Day
+
+**4 hrs 0 mins** on 2026-07-23
+
+#### Last Year — Languages
 
 ​```text
-TypeScript  ████████░░░░░░░░░░░░   40.1%  161h 25m
-Python      ████░░░░░░░░░░░░░░░░   18.3%  73h 40m
-​```
-
-#### Last Year Editors
-
-​```text
-VS Code     ██████████░░░░░░░░░░   52.9%  213h 10m
+TypeScript  ████████░░░░░░░░░░░░   40.1%  161 hrs 25 mins [AI 55% · Manual 45%]
+Python      ████░░░░░░░░░░░░░░░░   18.3%   73 hrs 40 mins [AI 40% · Manual 60%]
 ​```
 <!-- WAKATIME:END -->
 ```
 
 ## Configuration
 
-Configure which sections to display via the `wakatime.sections` key in `PLUGIN_CONFIG`. It accepts an array of section keys (`last30Total`, `last30Languages`, `last30Editors`, `allTimeTotal`, `allTimeLanguages`, `allTimeEditors`, `sinceToday`, `insightsLanguages`, `insightsEditors`). Sections render in the order given, and duplicates are ignored.
+Configure which sections to display via the `wakatime.sections` key in `PLUGIN_CONFIG`. It accepts an array of section keys, each being a window (`last7`, `last30`, `allTime`, `lastYear`) + facet (`Total`, `Languages`, `Editors`, `Categories`, `BestDay`) — e.g. `last7Total`, `last30Languages`, `allTimeCategories`, `lastYearBestDay` — plus the standalone `sinceToday`. Sections render in the order given, and duplicates are ignored.
 
 **If `sections` is omitted, only `last30Languages` is rendered** (the default).
 
@@ -123,7 +132,7 @@ Configure which sections to display via the `wakatime.sections` key in `PLUGIN_C
     PLUGIN_CONFIG: |
       {
         "wakatime": {
-          "sections": ["last30Total", "last30Languages", "last30Editors", "allTimeTotal", "allTimeLanguages", "allTimeEditors", "sinceToday", "insightsLanguages", "insightsEditors"]
+          "sections": ["last30Total", "last30Languages", "last30Editors", "last30Categories", "last30BestDay", "lastYearLanguages", "sinceToday"]
         }
       }
 ```

--- a/src/plugins/wakatime/index.ts
+++ b/src/plugins/wakatime/index.ts
@@ -1,11 +1,19 @@
 import type { Plugin } from '../../types.js';
 
 // --- Stats resource shapes (stats/:range) -------------------------------
+// Stat items carry percent + text, plus AI/manual second counts as strings.
 
 interface WakaTimeStatItem {
     name: string;
     percent: number;
     text: string;
+    ai_coding_seconds?: string;
+    manual_coding_seconds?: string;
+}
+
+interface WakaTimeBestDay {
+    date?: string;
+    text?: string;
 }
 
 interface WakaTimeStatsData {
@@ -13,6 +21,8 @@ interface WakaTimeStatsData {
     human_readable_daily_average?: string;
     languages?: WakaTimeStatItem[];
     editors?: WakaTimeStatItem[];
+    categories?: WakaTimeStatItem[];
+    best_day?: WakaTimeBestDay;
 }
 
 interface WakaTimeStatsResponse {
@@ -30,47 +40,36 @@ interface WakaTimeAllTimeResponse {
     data?: WakaTimeAllTimeData;
 }
 
-// --- Insights resource shapes (insights/:type/last_year) ----------------
-// Insight items have NO percent/text; only name + seconds + AI/manual split.
-
-interface WakaTimeInsightItem {
-    name: string;
-    total_seconds: number;
-}
-
-interface WakaTimeInsightData {
-    languages?: WakaTimeInsightItem[];
-    editors?: WakaTimeInsightItem[];
-    human_readable_range?: string;
-}
-
-interface WakaTimeInsightResponse {
-    data?: WakaTimeInsightData;
-}
-
 const BAR_LENGTH = 20;
 const BASE_URL = 'https://wakatime.com/api/v1/users/current';
 
-type SectionKey =
-    | 'last30Total'
-    | 'last30Languages'
-    | 'last30Editors'
-    | 'allTimeTotal'
-    | 'allTimeLanguages'
-    | 'allTimeEditors'
-    | 'sinceToday'
-    | 'insightsLanguages'
-    | 'insightsEditors';
+// --- Time windows -------------------------------------------------------
+// Each window maps to a free-tier stats/:range endpoint plus display labels.
+
+type WindowKey = 'last7' | 'last30' | 'allTime' | 'lastYear';
+
+interface WindowSpec {
+    path: string;
+    label: string;
+}
+
+const WINDOWS: Record<WindowKey, WindowSpec> = {
+    last7: { path: '/stats/last_7_days', label: 'Last 7 Days' },
+    last30: { path: '/stats/last_30_days', label: 'Last 30 Days' },
+    allTime: { path: '/stats/all_time', label: 'All Time' },
+    lastYear: { path: '/stats/last_year', label: 'Last Year' },
+};
+
+type Facet = 'Total' | 'Languages' | 'Editors' | 'Categories' | 'BestDay';
+
+const FACETS: readonly Facet[] = ['Total', 'Languages', 'Editors', 'Categories', 'BestDay'];
+const WINDOW_KEYS: readonly WindowKey[] = ['last7', 'last30', 'allTime', 'lastYear'];
+
+type SectionKey = `${WindowKey}${Facet}` | 'sinceToday';
+
 const VALID_SECTIONS: readonly SectionKey[] = [
-    'last30Total',
-    'last30Languages',
-    'last30Editors',
-    'allTimeTotal',
-    'allTimeLanguages',
-    'allTimeEditors',
+    ...WINDOW_KEYS.flatMap(w => FACETS.map(f => `${w}${f}` as SectionKey)),
     'sinceToday',
-    'insightsLanguages',
-    'insightsEditors',
 ];
 const DEFAULT_SECTIONS: readonly SectionKey[] = ['last30Languages'];
 
@@ -94,16 +93,20 @@ function makeBar(percent: number): string {
     return '█'.repeat(safeFilled) + '░'.repeat(BAR_LENGTH - safeFilled);
 }
 
-// Turn a raw second count into a compact "Xh Ym" human string, since the
-// insights endpoint (unlike stats) does not provide a human-readable text field.
-function humanizeSeconds(totalSeconds: number): string {
-    const totalMinutes = Math.round(totalSeconds / 60);
-    const hours = Math.floor(totalMinutes / 60);
-    const minutes = totalMinutes % 60;
-    if (hours > 0) {
-        return `${hours}h ${minutes}m`;
+// AI/manual second counts arrive as strings; produce a compact "AI 62% · Manual 38%"
+// annotation, returning '' when the split is unavailable or empty.
+function aiManualAnnotation(item: WakaTimeStatItem): string {
+    const ai = Number(item.ai_coding_seconds);
+    const manual = Number(item.manual_coding_seconds);
+    if (!Number.isFinite(ai) || !Number.isFinite(manual)) {
+        return '';
     }
-    return `${minutes}m`;
+    const total = ai + manual;
+    if (total <= 0) {
+        return '';
+    }
+    const aiPct = Math.round((ai / total) * 100);
+    return ` [AI ${aiPct}% · Manual ${100 - aiPct}%]`;
 }
 
 async function fetchJson<T>(path: string, authHeader: string): Promise<T | null> {
@@ -138,7 +141,8 @@ function createEndpointCache(authHeader: string): <T>(path: string) => Promise<T
 
 type EndpointFetch = <T>(path: string) => Promise<T | null>;
 
-// Renders top-N items that already carry percent + text (stats resource).
+// Renders top-N items that carry percent + text, annotating each with its
+// AI/manual coding split when available.
 function renderStatItems(items: WakaTimeStatItem[], topN: number): string {
     const top = items.slice(0, topN);
     if (top.length === 0) {
@@ -149,35 +153,20 @@ function renderStatItems(items: WakaTimeStatItem[], topN: number): string {
         const name = item.name.padEnd(maxNameLength, ' ');
         const bar = makeBar(item.percent);
         const percent = `${item.percent.toFixed(1)}%`.padStart(6, ' ');
-        return `${name}  ${bar}  ${percent}  ${item.text}`;
+        return `${name}  ${bar}  ${percent}  ${item.text}${aiManualAnnotation(item)}`;
     });
     return `\`\`\`text\n${lines.join('\n')}\n\`\`\`\n`;
 }
 
-// Renders top-N insight items, computing percent from the summed seconds
-// because insight items expose only name + total_seconds.
-function renderInsightItems(items: WakaTimeInsightItem[], topN: number): string {
-    if (items.length === 0) {
-        return '';
-    }
-    const totalSeconds = items.reduce((sum, item) => sum + item.total_seconds, 0);
-    if (totalSeconds <= 0) {
-        return '';
-    }
-    const top = items.slice(0, topN);
-    const maxNameLength = Math.max(...top.map(item => item.name.length));
-    const lines = top.map(item => {
-        const percentValue = (item.total_seconds / totalSeconds) * 100;
-        const name = item.name.padEnd(maxNameLength, ' ');
-        const bar = makeBar(percentValue);
-        const percent = `${percentValue.toFixed(1)}%`.padStart(6, ' ');
-        return `${name}  ${bar}  ${percent}  ${humanizeSeconds(item.total_seconds)}`;
-    });
-    return `\`\`\`text\n${lines.join('\n')}\n\`\`\`\n`;
+async function fetchWindow(
+    window: WindowKey,
+    fetchEndpoint: EndpointFetch,
+): Promise<WakaTimeStatsData | undefined> {
+    return (await fetchEndpoint<WakaTimeStatsResponse>(WINDOWS[window].path))?.data;
 }
 
-async function renderLast30Total(fetchEndpoint: EndpointFetch): Promise<string> {
-    const data = (await fetchEndpoint<WakaTimeStatsResponse>('/stats/last_30_days'))?.data;
+async function renderTotal(window: WindowKey, fetchEndpoint: EndpointFetch): Promise<string> {
+    const data = await fetchWindow(window, fetchEndpoint);
     if (!data) {
         return '';
     }
@@ -188,39 +177,34 @@ async function renderLast30Total(fetchEndpoint: EndpointFetch): Promise<string> 
     if (data.human_readable_daily_average) {
         summary.push(`**Daily average:** ${data.human_readable_daily_average}`);
     }
-    return summary.length > 0 ? `#### Last 30 Days\n\n${summary.join(' • ')}` : '';
+    return summary.length > 0 ? `#### ${WINDOWS[window].label}\n\n${summary.join(' • ')}` : '';
 }
 
-async function renderLast30Languages(fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
-    const data = (await fetchEndpoint<WakaTimeStatsResponse>('/stats/last_30_days'))?.data;
+async function renderLanguages(window: WindowKey, fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
+    const data = await fetchWindow(window, fetchEndpoint);
     const block = renderStatItems(data?.languages ?? [], topN);
-    return block ? `#### Last 30 Days — Languages\n\n${block}` : '';
+    return block ? `#### ${WINDOWS[window].label} — Languages\n\n${block}` : '';
 }
 
-async function renderLast30Editors(fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
-    const data = (await fetchEndpoint<WakaTimeStatsResponse>('/stats/last_30_days'))?.data;
+async function renderEditors(window: WindowKey, fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
+    const data = await fetchWindow(window, fetchEndpoint);
     const block = renderStatItems(data?.editors ?? [], topN);
-    return block ? `#### Last 30 Days — Editors\n\n${block}` : '';
+    return block ? `#### ${WINDOWS[window].label} — Editors\n\n${block}` : '';
 }
 
-async function renderAllTimeTotal(fetchEndpoint: EndpointFetch): Promise<string> {
-    const data = (await fetchEndpoint<WakaTimeStatsResponse>('/stats/all_time'))?.data;
-    if (!data?.human_readable_total) {
+async function renderCategories(window: WindowKey, fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
+    const data = await fetchWindow(window, fetchEndpoint);
+    const block = renderStatItems(data?.categories ?? [], topN);
+    return block ? `#### ${WINDOWS[window].label} — Categories\n\n${block}` : '';
+}
+
+async function renderBestDay(window: WindowKey, fetchEndpoint: EndpointFetch): Promise<string> {
+    const best = (await fetchWindow(window, fetchEndpoint))?.best_day;
+    if (!best?.text) {
         return '';
     }
-    return `#### All Time\n\n**Total:** ${data.human_readable_total}`;
-}
-
-async function renderAllTimeLanguages(fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
-    const data = (await fetchEndpoint<WakaTimeStatsResponse>('/stats/all_time'))?.data;
-    const block = renderStatItems(data?.languages ?? [], topN);
-    return block ? `#### All Time — Languages\n\n${block}` : '';
-}
-
-async function renderAllTimeEditors(fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
-    const data = (await fetchEndpoint<WakaTimeStatsResponse>('/stats/all_time'))?.data;
-    const block = renderStatItems(data?.editors ?? [], topN);
-    return block ? `#### All Time — Editors\n\n${block}` : '';
+    const date = best.date ? ` on ${best.date}` : '';
+    return `#### ${WINDOWS[window].label} — Best Day\n\n**${best.text}**${date}`;
 }
 
 async function renderSinceToday(fetchEndpoint: EndpointFetch): Promise<string> {
@@ -232,39 +216,38 @@ async function renderSinceToday(fetchEndpoint: EndpointFetch): Promise<string> {
     return `**All-Time Total:** ${data.text}${since}`;
 }
 
-async function renderInsightsLanguages(fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
-    const data = (await fetchEndpoint<WakaTimeInsightResponse>('/insights/languages/last_year'))?.data;
-    const block = renderInsightItems(data?.languages ?? [], topN);
-    return block ? `#### Last Year Languages\n\n${block}` : '';
-}
-
-async function renderInsightsEditors(fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
-    const data = (await fetchEndpoint<WakaTimeInsightResponse>('/insights/editors/last_year'))?.data;
-    const block = renderInsightItems(data?.editors ?? [], topN);
-    return block ? `#### Last Year Editors\n\n${block}` : '';
+function renderFacet(
+    window: WindowKey,
+    facet: Facet,
+    fetchEndpoint: EndpointFetch,
+    topN: number,
+): Promise<string> {
+    switch (facet) {
+        case 'Total':
+            return renderTotal(window, fetchEndpoint);
+        case 'Languages':
+            return renderLanguages(window, fetchEndpoint, topN);
+        case 'Editors':
+            return renderEditors(window, fetchEndpoint, topN);
+        case 'Categories':
+            return renderCategories(window, fetchEndpoint, topN);
+        case 'BestDay':
+            return renderBestDay(window, fetchEndpoint);
+    }
 }
 
 async function renderSection(key: SectionKey, fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
-    switch (key) {
-        case 'last30Total':
-            return renderLast30Total(fetchEndpoint);
-        case 'last30Languages':
-            return renderLast30Languages(fetchEndpoint, topN);
-        case 'last30Editors':
-            return renderLast30Editors(fetchEndpoint, topN);
-        case 'allTimeTotal':
-            return renderAllTimeTotal(fetchEndpoint);
-        case 'allTimeLanguages':
-            return renderAllTimeLanguages(fetchEndpoint, topN);
-        case 'allTimeEditors':
-            return renderAllTimeEditors(fetchEndpoint, topN);
-        case 'sinceToday':
-            return renderSinceToday(fetchEndpoint);
-        case 'insightsLanguages':
-            return renderInsightsLanguages(fetchEndpoint, topN);
-        case 'insightsEditors':
-            return renderInsightsEditors(fetchEndpoint, topN);
+    if (key === 'sinceToday') {
+        return renderSinceToday(fetchEndpoint);
     }
+    for (const window of WINDOW_KEYS) {
+        for (const facet of FACETS) {
+            if (key === `${window}${facet}`) {
+                return renderFacet(window, facet, fetchEndpoint, topN);
+            }
+        }
+    }
+    return '';
 }
 
 const wakatimePlugin: Plugin = async (_octokit, _username, config) => {


### PR DESCRIPTION
Expands the WakaTime plugin from stats-only 30-day/all-time/insights keys into a fully windowed, faceted configuration.

## What changed
- **Time windows**: `last7`, `last30`, `allTime`, `lastYear` (all free-tier `stats/<range>` endpoints; `last_6_months` deliberately excluded — returns 202/stale on free tier).
- **Facets** per window: `Total`, `Languages`, `Editors`, `Categories`, `BestDay` — e.g. `last7Languages`, `allTimeCategories`, `lastYearBestDay`.
- **AI/manual split**: language/editor/category bars now annotate each item inline with its AI-assisted vs. manual coding split (e.g. `[AI 62% · Manual 38%]`) parsed from the stats items' `ai_coding_seconds`/`manual_coding_seconds`.
- **Removed** the `insightsLanguages`/`insightsEditors` keys and the entire insights code path — `stats/last_year` (via `lastYearLanguages`/`lastYearEditors`) supersedes them with richer percent + text + AI/manual data.
- Per-run endpoint cache retained: all facets of one window share a single HTTP request.
- `DEFAULT_SECTIONS` stays `['last30Languages']` (backward compatible default).

## Config
`sections` is an array of `<window><Facet>` keys plus standalone `sinceToday`. Renders in order, dedup via Set.

## Verification
- `npm run build` exit 0
- `npx tsc --noEmit` exit 0 (strict tsconfig)
- Endpoint availability + response shapes live-probed against a free WakaTime account.

BREAKING: profile `PLUGIN_CONFIG` using `insightsLanguages`/`insightsEditors` must migrate to `lastYearLanguages`/`lastYearEditors`.