### PR TITLE
feat(core): per-section plugin markers via map return contract

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,17 +146,22 @@ Our system is designed to make adding new plugins easy.
 
 2. **Implement the Plugin**: Inside this new folder, create an `index.ts` file. This file must export a default function that conforms to the Plugin type defined in `src/types.ts`.
 
+   A plugin returns a `PluginSections` map (`Record<string, string>`) of marker suffix to content. The engine replaces each `<!-- <PLUGINNAME_SUFFIX>:START -->` / `<!-- <PLUGINNAME_SUFFIX>:END -->` pair in the README with the matching content. An empty-string key (`''`) targets the plugin's bare marker `<!-- <PLUGINNAME>:START/END -->`; a non-empty suffix targets `<!-- <PLUGINNAME>_<SUFFIX>:START/END -->`. Suffixes let one plugin populate several independent markers (e.g. arranged side by side in an HTML table). Sections whose markers are absent from the README are silently skipped.
+
    ```ts
    // src/plugins/my-plugin/index.ts
-   import { Plugin } from "../../types.js";
+   import type { Plugin } from "../../types.js";
 
    const myPlugin: Plugin = async (octokit, username, config) => {
      // Your plugin logic here...
-     return `Hello, ${username}!`;
+     // Single-marker plugin: use the '' key to target <!-- MY-PLUGIN:START/END -->
+     return { "": `Hello, ${username}!` };
    };
 
    export default myPlugin;
    ```
+
+   To emit multiple independent markers, return more keys, e.g. `{ GREETING: "Hi!", FOOTER: "Bye!" }` populates `<!-- MY-PLUGIN_GREETING:START/END -->` and `<!-- MY-PLUGIN_FOOTER:START/END -->`.
 
 3. That's It! The plugin registry is automatically updated. The next time you run npm test, `npm run test:local`, or `npm run build`, the pre script will run and automatically add your new plugin to `src/plugins/index.ts`.
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -16,14 +16,18 @@ export default async function runCore(octokit: Octokit, username: string, plugin
             try {
                 console.log(`Running plugin: ${pluginName}...`);
 
-                const result = await plugin(octokit, username, pluginConfig[pluginName] || {});
-                const tagName = pluginName.toUpperCase();
-                const startComment = `<!-- ${tagName}:START -->`;
-                const endComment = `<!-- ${tagName}:END -->`;
-                const replacement = `${startComment}\n${result}\n${endComment}`;
-                const regex = new RegExp(`${escapeRegExp(startComment)}[\\s\\S]*${escapeRegExp(endComment)}`);
+                const sections = await plugin(octokit, username, pluginConfig[pluginName] || {});
+                const baseTag = pluginName.toUpperCase();
 
-                newReadmeContent = newReadmeContent.replace(regex, replacement);
+                for (const [suffix, content] of Object.entries(sections)) {
+                    const tagName = suffix ? `${baseTag}_${suffix}` : baseTag;
+                    const startComment = `<!-- ${tagName}:START -->`;
+                    const endComment = `<!-- ${tagName}:END -->`;
+                    const replacement = `${startComment}\n${content}\n${endComment}`;
+                    const regex = new RegExp(`${escapeRegExp(startComment)}[\\s\\S]*${escapeRegExp(endComment)}`);
+
+                    newReadmeContent = newReadmeContent.replace(regex, replacement);
+                }
                 console.log(`Plugin ${pluginName} finished successfully.`);
 
             } catch (error) {

--- a/src/plugins/notable-contributions/index.ts
+++ b/src/plugins/notable-contributions/index.ts
@@ -24,7 +24,7 @@ const notableContributionsPlugin: Plugin = async (octokit, username, config) => 
         prList += 'No notable contributions found.';
     }
 
-    return prList;
+    return { '': prList };
 }
 
 export default notableContributionsPlugin;

--- a/src/plugins/prs/index.ts
+++ b/src/plugins/prs/index.ts
@@ -24,7 +24,7 @@ const prsPlugin: Plugin = async (octokit, username, config) => {
         prList += 'No recent merged PRs found.';
     }
 
-    return prList;
+    return { '': prList };
 }
 
 export default prsPlugin;

--- a/src/plugins/wakatime/README.md
+++ b/src/plugins/wakatime/README.md
@@ -1,6 +1,6 @@
 # WakaTime Plugin
 
-This plugin fetches and displays your coding activity from [WakaTime](https://wakatime.com) as a single combined block. You choose which sections to render via the `sections` config option.
+This plugin fetches and displays your coding activity from [WakaTime](https://wakatime.com). You choose which sections to render via the `sections` config option, and **each selected section is emitted under its own marker** so you can place sections anywhere in your README — including side by side inside an HTML table.
 
 Each section key is a **time window** (`last7`, `last30`, `allTime`, `lastYear`) combined with a **facet** (`Total`, `Languages`, `Editors`, `Categories`, `BestDay`), giving keys like `last30Languages` or `allTimeCategories`. There is also a standalone `sinceToday` key. Every window reads a `stats/:range` endpoint that is accessible on the free tier.
 
@@ -59,60 +59,60 @@ To enable this plugin, include `wakatime` in the `PLUGINS` input and pass the AP
 
 The API key is read from the environment (`process.env.WAKATIME_API_KEY`) and is intentionally **not** part of `PLUGIN_CONFIG`, keeping the secret out of the README output and config JSON.
 
-## Placeholder
+## Placeholders
 
-Add the following placeholder comments to your target Markdown file where you want the stats injected:
+Each selected section is injected into **its own marker pair**, named `WAKATIME_<SECTIONKEY>` where `<SECTIONKEY>` is the config key uppercased. Add a marker pair for every section you list in `sections`:
 
 ```markdown
-<!-- WAKATIME:START -->
-<!-- WAKATIME:END -->
+<!-- WAKATIME_LAST30LANGUAGES:START -->
+<!-- WAKATIME_LAST30LANGUAGES:END -->
+
+<!-- WAKATIME_SINCETODAY:START -->
+<!-- WAKATIME_SINCETODAY:END -->
 ```
 
-The content between these comments is automatically replaced by the generated WakaTime stats block.
+The content between each pair is automatically replaced with that section's rendered output. Only markers you add are populated — a section with no matching marker is silently skipped.
+
+### Side-by-side layout
+
+Because every section has its own marker, you can wrap them in an HTML table to render sections in columns. The plugin renders bars inside `<pre>` blocks (not fenced code), which display correctly inside `<td>` cells on GitHub:
+
+```html
+<table>
+  <tr>
+    <td>
+      <!-- WAKATIME_LAST30LANGUAGES:START -->
+      <!-- WAKATIME_LAST30LANGUAGES:END -->
+    </td>
+    <td>
+      <!-- WAKATIME_ALLTIMELANGUAGES:START -->
+      <!-- WAKATIME_ALLTIMELANGUAGES:END -->
+    </td>
+  </tr>
+</table>
+```
 
 ## Example Output
 
-```markdown
-<!-- WAKATIME:START -->
-### WakaTime
+With `sections: ["last30Languages", "sinceToday"]`, the `WAKATIME_LAST30LANGUAGES` marker is populated with:
 
-**All-Time Total:** 2,264 hrs 20 mins (since Thu Sep 3rd 2020)
-
-#### Last 30 Days
-
-**Total:** 42 hrs 18 mins • **Daily average:** 1 hr 24 mins
-
+```html
+<!-- WAKATIME_LAST30LANGUAGES:START -->
 #### Last 30 Days — Languages
 
-​```text
+<pre>
 TypeScript  ██████████░░░░░░░░░░   48.2%  20 hrs 24 mins [AI 61% · Manual 39%]
 Python      █████░░░░░░░░░░░░░░░░   24.1%  10 hrs 12 mins [AI 45% · Manual 55%]
-​```
+</pre>
+<!-- WAKATIME_LAST30LANGUAGES:END -->
+```
 
-#### Last 30 Days — Editors
+…and the `WAKATIME_SINCETODAY` marker with:
 
-​```text
-VS Code     ████████████████░░░░   82.5%  34 hrs 54 mins [AI 58% · Manual 42%]
-​```
-
-#### Last 30 Days — Categories
-
-​```text
-AI Coding   ███████████████░░░░░   73.2%  30 hrs 58 mins
-Coding      ██░░░░░░░░░░░░░░░░░░░   10.3%   4 hrs 21 mins
-​```
-
-#### Last 30 Days — Best Day
-
-**4 hrs 0 mins** on 2026-07-23
-
-#### Last Year — Languages
-
-​```text
-TypeScript  ████████░░░░░░░░░░░░   40.1%  161 hrs 25 mins [AI 55% · Manual 45%]
-Python      ████░░░░░░░░░░░░░░░░   18.3%   73 hrs 40 mins [AI 40% · Manual 60%]
-​```
-<!-- WAKATIME:END -->
+```html
+<!-- WAKATIME_SINCETODAY:START -->
+**All-Time Total:** 2,264 hrs 20 mins (since Thu Sep 3rd 2020)
+<!-- WAKATIME_SINCETODAY:END -->
 ```
 
 ## Configuration

--- a/src/plugins/wakatime/index.ts
+++ b/src/plugins/wakatime/index.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../../types.js';
+import type { Plugin, PluginSections } from '../../types.js';
 
 // --- Stats resource shapes (stats/:range) -------------------------------
 // Stat items carry percent + text, plus AI/manual second counts as strings.
@@ -155,7 +155,7 @@ function renderStatItems(items: WakaTimeStatItem[], topN: number): string {
         const percent = `${item.percent.toFixed(1)}%`.padStart(6, ' ');
         return `${name}  ${bar}  ${percent}  ${item.text}${aiManualAnnotation(item)}`;
     });
-    return `\`\`\`text\n${lines.join('\n')}\n\`\`\`\n`;
+    return `<pre>\n${lines.join('\n')}\n</pre>`;
 }
 
 async function fetchWindow(
@@ -251,11 +251,9 @@ async function renderSection(key: SectionKey, fetchEndpoint: EndpointFetch, topN
 }
 
 const wakatimePlugin: Plugin = async (_octokit, _username, config) => {
-    const heading = '### WakaTime\n\n';
-
     const apiKey = process.env.WAKATIME_API_KEY;
     if (!apiKey) {
-        return `${heading}WakaTime stats are unavailable because the \`WAKATIME_API_KEY\` secret is not set.`;
+        return { '': '### WakaTime\n\nWakaTime stats are unavailable because the `WAKATIME_API_KEY` secret is not set.' };
     }
 
     const topN = parseInt(String((config as { maxPrs?: number }).maxPrs ?? 5), 10);
@@ -267,16 +265,17 @@ const wakatimePlugin: Plugin = async (_octokit, _username, config) => {
         const rendered = await Promise.all(
             selected.map(key => renderSection(key, fetchEndpoint, topN)),
         );
-        const sections = rendered.filter(Boolean);
-
-        if (sections.length === 0) {
-            return `${heading}No WakaTime data available yet.`;
-        }
-
-        return `${heading}${sections.join('\n\n').trimEnd()}`;
+        const output: PluginSections = {};
+        selected.forEach((key, index) => {
+            const content = rendered[index];
+            if (content) {
+                output[key.toUpperCase()] = content;
+            }
+        });
+        return output;
     } catch (error) {
         console.error('Error fetching WakaTime stats:', error);
-        return `${heading}An error occurred while fetching WakaTime stats.`;
+        return { '': '### WakaTime\n\nAn error occurred while fetching WakaTime stats.' };
     }
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,15 @@ export interface BasePluginConfig {
 }
 
 /**
+ * The value a plugin returns: a map of marker suffix -> rendered content.
+ * An empty-string suffix targets the plugin's base marker
+ * `<!-- NAME:START/END -->`; a non-empty suffix targets
+ * `<!-- NAME_SUFFIX:START/END -->`, letting one plugin populate many
+ * independent marker pairs (e.g. side-by-side layouts in an HTML table).
+ */
+export type PluginSections = Record<string, string>;
+
+/**
  * Defines the function signature for a readme-engine plugin.
  * This is the "contract" that all plugins must adhere to.
  */
@@ -22,7 +31,7 @@ export type Plugin = (
   octokit: Octokit,
   username: string,
   config: BasePluginConfig
-) => Promise<string>;
+) => Promise<PluginSections>;
 
 /**
  * Defines the shape of a dynamically imported plugin module.


### PR DESCRIPTION
Changes the plugin return contract from Promise<string> to Promise<PluginSections> (a Record<string, string> map of marker suffix to content), enabling each plugin to populate multiple independent README markers.

## Core / contract
- src/types.ts: add PluginSections = Record<string, string>; Plugin now returns Promise<PluginSections>.
- src/core.ts: iterate the returned map; for each [suffix, content] replace <!-- NAME:START/END --> (empty suffix) or <!-- NAME_SUFFIX:START/END --> independently. Markers absent from the README are no-ops.

## Plugin migrations (clean break, no back-compat)
- prs, 
otable-contributions: return { '': ... } (bare marker).
- wakatime: emit one map entry per selected section keyed by the section key uppercased (e.g. WAKATIME_LAST30LANGUAGES). Bars now render as <pre> instead of triple-backtick fenced blocks so they display correctly inside HTML <td> cells for side-by-side layouts.

## Docs
- CONTRIBUTING.md, src/plugins/wakatime/README.md updated for the map contract, per-section markers, and side-by-side example.

Verified: 
pm run build and 
px tsc --noEmit both exit 0.