### PR TITLE
feat(wakatime): use bold inline labels for total and best-day text outputs

### DIFF
--- a/src/plugins/wakatime/index.ts
+++ b/src/plugins/wakatime/index.ts
@@ -231,12 +231,12 @@ async function renderTotal(window: WindowKey, fetchEndpoint: EndpointFetch): Pro
     }
     const summary: string[] = [];
     if (data.human_readable_total) {
-        summary.push(`**Total:** ${data.human_readable_total}`);
+        summary.push(`Total: ${data.human_readable_total}`);
     }
     if (data.human_readable_daily_average) {
-        summary.push(`**Daily average:** ${data.human_readable_daily_average}`);
+        summary.push(`Daily average: ${data.human_readable_daily_average}`);
     }
-    return summary.length > 0 ? `#### ${WINDOWS[window].label}\n\n${summary.join(' • ')}` : '';
+    return summary.length > 0 ? `**${WINDOWS[window].label}** — ${summary.join(' • ')}` : '';
 }
 
 async function renderLanguages(window: WindowKey, fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
@@ -263,7 +263,7 @@ async function renderBestDay(window: WindowKey, fetchEndpoint: EndpointFetch): P
         return '';
     }
     const date = best.date ? ` on ${best.date}` : '';
-    return `#### ${WINDOWS[window].label} — Best Day\n\n**${best.text}**${date}`;
+    return `**${WINDOWS[window].label} Best Day** — ${best.text}${date}`;
 }
 
 async function renderSinceToday(fetchEndpoint: EndpointFetch): Promise<string> {


### PR DESCRIPTION
Downgrades the h4 headings on the text (non-bar) WakaTime outputs to bold inline labels for a tighter, uniform text band. renderTotal emits bold-label Total/Daily-average; renderBestDay emits bold-label best day. Bar-chart outputs (Languages/Editors/Categories) keep their h4 headings.