### PR TITLE
feat(wakatime): use bold colon labels for bar chart sections

### DIFF
--- a/src/plugins/wakatime/README.md
+++ b/src/plugins/wakatime/README.md
@@ -104,7 +104,7 @@ With `sections: ["last30Languages", "sinceToday"]`, the `WAKATIME_LAST30LANGUAGE
 
 ```html
 <!-- WAKATIME_LAST30LANGUAGES:START -->
-#### Last 30 Days — Languages
+**Last 30 Days: Languages**
 
 <pre>
 TypeScript  ██████████░░░░░░░░░░   48.2%  20 hrs 24 mins [AI 61% · Manual 39%]

--- a/src/plugins/wakatime/index.ts
+++ b/src/plugins/wakatime/index.ts
@@ -242,19 +242,19 @@ async function renderTotal(window: WindowKey, fetchEndpoint: EndpointFetch): Pro
 async function renderLanguages(window: WindowKey, fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
     const data = await fetchWindow(window, fetchEndpoint);
     const block = renderStatItems(data?.languages ?? [], topN);
-    return block ? `#### ${WINDOWS[window].label} — Languages\n\n${block}` : '';
+    return block ? `**${WINDOWS[window].label}: Languages**\n\n${block}` : '';
 }
 
 async function renderEditors(window: WindowKey, fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
     const data = await fetchWindow(window, fetchEndpoint);
     const block = renderStatItems(data?.editors ?? [], topN);
-    return block ? `#### ${WINDOWS[window].label} — Editors\n\n${block}` : '';
+    return block ? `**${WINDOWS[window].label}: Editors**\n\n${block}` : '';
 }
 
 async function renderCategories(window: WindowKey, fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
     const data = await fetchWindow(window, fetchEndpoint);
     const block = renderStatItems(data?.categories ?? [], topN);
-    return block ? `#### ${WINDOWS[window].label} — Categories\n\n${block}` : '';
+    return block ? `**${WINDOWS[window].label}: Categories**\n\n${block}` : '';
 }
 
 async function renderBestDay(window: WindowKey, fetchEndpoint: EndpointFetch): Promise<string> {
@@ -299,8 +299,8 @@ async function renderSummaries(fetchEndpoint: EndpointFetch): Promise<string> {
     });
     const total = response?.cumulative_total?.text;
     const heading = total
-        ? `#### Last 7 Days — Activity\n\n**Total:** ${total}`
-        : '#### Last 7 Days — Activity';
+        ? `**Last 7 Days: Activity**\n\n**Total:** ${total}`
+        : '**Last 7 Days: Activity**';
     return `${heading}\n\n<pre>\n${lines.join('\n')}\n</pre>`;
 }
 
@@ -322,7 +322,7 @@ async function renderProjects(fetchEndpoint: EndpointFetch, topN: number): Promi
         return '';
     }
     const list = names.map(name => `- ${name}`).join('\n');
-    return `#### Recent Projects\n\n${list}`;
+    return `**Recent Projects**\n\n${list}`;
 }
 
 async function renderLeaders(fetchEndpoint: EndpointFetch): Promise<string> {


### PR DESCRIPTION
Replaces the #### headings on bar-chart / list sections with bold colon labels (**Last 30 Days: Languages**, **Last 7 Days: Activity**, **Recent Projects**) so every WakaTime section uses a consistent bold label style. No more h4 headings in the plugin output.