### PR TITLE
feat(wakatime): add today window and AI cost and tokens facets

### DIFF
--- a/src/plugins/wakatime/README.md
+++ b/src/plugins/wakatime/README.md
@@ -2,18 +2,19 @@
 
 This plugin fetches and displays your coding activity from [WakaTime](https://wakatime.com). You choose which sections to render via the `sections` config option, and **each selected section is emitted under its own marker** so you can place sections anywhere in your README — including side by side inside an HTML table.
 
-Each section key is a **time window** (`last7`, `last30`, `allTime`, `lastYear`) combined with a **facet** (`Total`, `Languages`, `Editors`, `Categories`, `BestDay`), giving keys like `last30Languages` or `allTimeCategories`. There is also a standalone `sinceToday` key. Every window reads a `stats/:range` endpoint that is accessible on the free tier.
+Each section key is a **time window** (`today`, `last7`, `last30`, `allTime`, `lastYear`) combined with a **facet** (`Total`, `Languages`, `Editors`, `Categories`, `BestDay`, `AiCost`, `AiTokens`), giving keys like `last30Languages` or `todayAiCost`. There is also a standalone `sinceToday` key. Every window reads a free-tier endpoint.
 
-**Windows** (each reads `stats/<range>`):
+**Windows:**
 
 | Window     | Range              | Endpoint               |
 | ---------- | ------------------ | ---------------------- |
+| `today`    | Today so far       | `status_bar/today`     |
 | `last7`    | Last 7 days        | `stats/last_7_days`    |
 | `last30`   | Last 30 days       | `stats/last_30_days`   |
 | `allTime`  | Lifetime           | `stats/all_time`       |
 | `lastYear` | Rolling 12 months  | `stats/last_year`      |
 
-**Facets** (append to any window, e.g. `last7Languages`):
+**Facets** (append to any window, e.g. `last7Languages`, `todayAiCost`):
 
 | Facet        | Renders                                                                    |
 | ------------ | -------------------------------------------------------------------------- |
@@ -22,6 +23,10 @@ Each section key is a **time window** (`last7`, `last30`, `allTime`, `lastYear`)
 | `Editors`    | Top editors with percentages, bars, and per-item AI/manual split.          |
 | `Categories` | Top activity categories (e.g. AI Coding, Writing Docs) with percentages.   |
 | `BestDay`    | The single most productive day in the window.                              |
+| `AiCost`     | Total AI model spend plus a per-model cost breakdown with bars.            |
+| `AiTokens`   | AI input and output token counts (abbreviated, e.g. `4.2M`).               |
+
+> The `today` window omits `Total`'s daily-average line and has no `BestDay` (a single day); those render nothing.
 
 **Standalone keys:**
 

--- a/src/plugins/wakatime/index.ts
+++ b/src/plugins/wakatime/index.ts
@@ -16,6 +16,11 @@ interface WakaTimeBestDay {
     text?: string;
 }
 
+interface WakaTimeAiModel {
+    name?: string;
+    cost?: number;
+}
+
 interface WakaTimeStatsData {
     human_readable_total?: string;
     human_readable_daily_average?: string;
@@ -23,6 +28,10 @@ interface WakaTimeStatsData {
     editors?: WakaTimeStatItem[];
     categories?: WakaTimeStatItem[];
     best_day?: WakaTimeBestDay;
+    ai_model_total_cost?: number;
+    ai_model_breakdown?: WakaTimeAiModel[];
+    ai_input_tokens?: number;
+    ai_output_tokens?: number;
 }
 
 interface WakaTimeStatsResponse {
@@ -45,6 +54,10 @@ interface WakaTimeAllTimeResponse {
 interface WakaTimeGrandTotal {
     text?: string;
     total_seconds?: number;
+    ai_model_total_cost?: number;
+    ai_model_breakdown?: WakaTimeAiModel[];
+    ai_input_tokens?: number;
+    ai_output_tokens?: number;
 }
 
 interface WakaTimeSummariesDay {
@@ -62,7 +75,12 @@ interface WakaTimeSummariesResponse {
 }
 
 interface WakaTimeStatusBarResponse {
-    data?: { grand_total?: WakaTimeGrandTotal };
+    data?: {
+        grand_total?: WakaTimeGrandTotal;
+        languages?: WakaTimeStatItem[];
+        editors?: WakaTimeStatItem[];
+        categories?: WakaTimeStatItem[];
+    };
 }
 
 interface WakaTimeProject {
@@ -92,24 +110,28 @@ const BASE_URL = 'https://wakatime.com/api/v1/users/current';
 // --- Time windows -------------------------------------------------------
 // Each window maps to a free-tier stats/:range endpoint plus display labels.
 
-type WindowKey = 'last7' | 'last30' | 'allTime' | 'lastYear';
+type WindowKey = 'today' | 'last7' | 'last30' | 'allTime' | 'lastYear';
 
 interface WindowSpec {
     path: string;
     label: string;
+    // status_bar/today nests totals/AI under data.grand_total and omits best_day;
+    // stats/:range exposes them at the top level. Flag the shape so fetchWindow normalizes.
+    statusBar?: boolean;
 }
 
 const WINDOWS: Record<WindowKey, WindowSpec> = {
+    today: { path: '/status_bar/today', label: 'Today', statusBar: true },
     last7: { path: '/stats/last_7_days', label: 'Last 7 Days' },
     last30: { path: '/stats/last_30_days', label: 'Last 30 Days' },
     allTime: { path: '/stats/all_time', label: 'All Time' },
     lastYear: { path: '/stats/last_year', label: 'Last Year' },
 };
 
-type Facet = 'Total' | 'Languages' | 'Editors' | 'Categories' | 'BestDay';
+type Facet = 'Total' | 'Languages' | 'Editors' | 'Categories' | 'BestDay' | 'AiCost' | 'AiTokens';
 
-const FACETS: readonly Facet[] = ['Total', 'Languages', 'Editors', 'Categories', 'BestDay'];
-const WINDOW_KEYS: readonly WindowKey[] = ['last7', 'last30', 'allTime', 'lastYear'];
+const FACETS: readonly Facet[] = ['Total', 'Languages', 'Editors', 'Categories', 'BestDay', 'AiCost', 'AiTokens'];
+const WINDOW_KEYS: readonly WindowKey[] = ['today', 'last7', 'last30', 'allTime', 'lastYear'];
 
 type StandaloneKey = 'sinceToday' | 'summaries' | 'today' | 'projects' | 'leaders' | 'goals' | 'durations';
 
@@ -221,7 +243,25 @@ async function fetchWindow(
     window: WindowKey,
     fetchEndpoint: EndpointFetch,
 ): Promise<WakaTimeStatsData | undefined> {
-    return (await fetchEndpoint<WakaTimeStatsResponse>(WINDOWS[window].path))?.data;
+    const spec = WINDOWS[window];
+    if (!spec.statusBar) {
+        return (await fetchEndpoint<WakaTimeStatsResponse>(spec.path))?.data;
+    }
+    const data = (await fetchEndpoint<WakaTimeStatusBarResponse>(spec.path))?.data;
+    if (!data) {
+        return undefined;
+    }
+    const grand = data.grand_total ?? {};
+    return {
+        ...(grand.text !== undefined && { human_readable_total: grand.text }),
+        ...(data.languages !== undefined && { languages: data.languages }),
+        ...(data.editors !== undefined && { editors: data.editors }),
+        ...(data.categories !== undefined && { categories: data.categories }),
+        ...(grand.ai_model_total_cost !== undefined && { ai_model_total_cost: grand.ai_model_total_cost }),
+        ...(grand.ai_model_breakdown !== undefined && { ai_model_breakdown: grand.ai_model_breakdown }),
+        ...(grand.ai_input_tokens !== undefined && { ai_input_tokens: grand.ai_input_tokens }),
+        ...(grand.ai_output_tokens !== undefined && { ai_output_tokens: grand.ai_output_tokens }),
+    };
 }
 
 async function renderTotal(window: WindowKey, fetchEndpoint: EndpointFetch): Promise<string> {
@@ -264,6 +304,57 @@ async function renderBestDay(window: WindowKey, fetchEndpoint: EndpointFetch): P
     }
     const date = best.date ? ` on ${best.date}` : '';
     return `**${WINDOWS[window].label} Best Day:** ${best.text}${date}`;
+}
+
+function abbreviateCount(value: number): string {
+    if (value >= 1_000_000) {
+        return `${(value / 1_000_000).toFixed(1)}M`;
+    }
+    if (value >= 1_000) {
+        return `${(value / 1_000).toFixed(1)}K`;
+    }
+    return String(value);
+}
+
+async function renderAiCost(window: WindowKey, fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
+    const data = await fetchWindow(window, fetchEndpoint);
+    const total = data?.ai_model_total_cost;
+    if (total === undefined || total <= 0) {
+        return '';
+    }
+    const header = `**${WINDOWS[window].label}: AI Cost**\n\n**Total:** $${total.toFixed(2)}`;
+    const models = (data?.ai_model_breakdown ?? [])
+        .filter((model): model is WakaTimeAiModel & { name: string; cost: number } =>
+            typeof model.name === 'string' && typeof model.cost === 'number' && model.cost > 0)
+        .sort((a, b) => b.cost - a.cost)
+        .slice(0, topN);
+    if (models.length === 0) {
+        return header;
+    }
+    const maxNameLength = Math.max(...models.map(model => model.name.length));
+    const lines = models.map(model => {
+        const name = model.name.padEnd(maxNameLength, ' ');
+        const bar = makeBar((model.cost / total) * 100);
+        return `${name}  ${bar}  $${model.cost.toFixed(2)}`;
+    });
+    return `${header}\n\n<pre>\n${lines.join('\n')}\n</pre>`;
+}
+
+async function renderAiTokens(window: WindowKey, fetchEndpoint: EndpointFetch): Promise<string> {
+    const data = await fetchWindow(window, fetchEndpoint);
+    const input = data?.ai_input_tokens;
+    const output = data?.ai_output_tokens;
+    if ((input === undefined || input <= 0) && (output === undefined || output <= 0)) {
+        return '';
+    }
+    const parts: string[] = [];
+    if (input !== undefined && input > 0) {
+        parts.push(`**Input:** ${abbreviateCount(input)}`);
+    }
+    if (output !== undefined && output > 0) {
+        parts.push(`**Output:** ${abbreviateCount(output)}`);
+    }
+    return `**${WINDOWS[window].label}: AI Tokens**\n\n${parts.join(' • ')}`;
 }
 
 async function renderSinceToday(fetchEndpoint: EndpointFetch): Promise<string> {
@@ -388,6 +479,10 @@ function renderFacet(
             return renderCategories(window, fetchEndpoint, topN);
         case 'BestDay':
             return renderBestDay(window, fetchEndpoint);
+        case 'AiCost':
+            return renderAiCost(window, fetchEndpoint, topN);
+        case 'AiTokens':
+            return renderAiTokens(window, fetchEndpoint);
     }
 }
 


### PR DESCRIPTION
Adds a `today` window (sourced from /status_bar/today) and two new facets (AiCost, AiTokens) to the WakaTime plugin.

## What's new
- **today window**: covers Total, Languages, Editors, Categories, AiCost, AiTokens. Sourced from /status_bar/today; grand_total is normalized into the stats shape. No BestDay / daily-average for today (those render nothing).
- **AiCost facet**: total AI model spend plus a per-model cost breakdown with bars, for any window.
- **AiTokens facet**: AI input/output token counts, abbreviated (e.g. 4.2M).

## Notes
- Reuses /stats/:range for the non-today windows (memoized per-path).
- All free-tier accessible; verified against a free account.
- Colon-form bold labels, consistent with v2.14.0.

## Verification
- npm run build (ncc) exit 0
- npx tsc --noEmit exit 0