### PR TITLE
fix(wakatime): one-line AI tokens and colon-suffix section headings

### DIFF
--- a/src/plugins/wakatime/README.md
+++ b/src/plugins/wakatime/README.md
@@ -109,7 +109,7 @@ With `sections: ["last30Languages", "sinceToday"]`, the `WAKATIME_LAST30LANGUAGE
 
 ```html
 <!-- WAKATIME_LAST30LANGUAGES:START -->
-**Last 30 Days: Languages**
+**Last 30 Days Languages:**
 
 <pre>
 TypeScript  ██████████░░░░░░░░░░   48.2%  20 hrs 24 mins [AI 61% · Manual 39%]

--- a/src/plugins/wakatime/index.ts
+++ b/src/plugins/wakatime/index.ts
@@ -282,19 +282,19 @@ async function renderTotal(window: WindowKey, fetchEndpoint: EndpointFetch): Pro
 async function renderLanguages(window: WindowKey, fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
     const data = await fetchWindow(window, fetchEndpoint);
     const block = renderStatItems(data?.languages ?? [], topN);
-    return block ? `**${WINDOWS[window].label}: Languages**\n\n${block}` : '';
+    return block ? `**${WINDOWS[window].label} Languages:**\n\n${block}` : '';
 }
 
 async function renderEditors(window: WindowKey, fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
     const data = await fetchWindow(window, fetchEndpoint);
     const block = renderStatItems(data?.editors ?? [], topN);
-    return block ? `**${WINDOWS[window].label}: Editors**\n\n${block}` : '';
+    return block ? `**${WINDOWS[window].label} Editors:**\n\n${block}` : '';
 }
 
 async function renderCategories(window: WindowKey, fetchEndpoint: EndpointFetch, topN: number): Promise<string> {
     const data = await fetchWindow(window, fetchEndpoint);
     const block = renderStatItems(data?.categories ?? [], topN);
-    return block ? `**${WINDOWS[window].label}: Categories**\n\n${block}` : '';
+    return block ? `**${WINDOWS[window].label} Categories:**\n\n${block}` : '';
 }
 
 async function renderBestDay(window: WindowKey, fetchEndpoint: EndpointFetch): Promise<string> {
@@ -322,7 +322,7 @@ async function renderAiCost(window: WindowKey, fetchEndpoint: EndpointFetch, top
     if (total === undefined || total <= 0) {
         return '';
     }
-    const header = `**${WINDOWS[window].label}: AI Cost**\n\n**Total:** $${total.toFixed(2)}`;
+    const header = `**${WINDOWS[window].label} AI Cost:**\n\n**Total:** $${total.toFixed(2)}`;
     const models = (data?.ai_model_breakdown ?? [])
         .filter((model): model is WakaTimeAiModel & { name: string; cost: number } =>
             typeof model.name === 'string' && typeof model.cost === 'number' && model.cost > 0)
@@ -349,12 +349,12 @@ async function renderAiTokens(window: WindowKey, fetchEndpoint: EndpointFetch): 
     }
     const parts: string[] = [];
     if (input !== undefined && input > 0) {
-        parts.push(`**Input:** ${abbreviateCount(input)}`);
+        parts.push(`${abbreviateCount(input)} in`);
     }
     if (output !== undefined && output > 0) {
-        parts.push(`**Output:** ${abbreviateCount(output)}`);
+        parts.push(`${abbreviateCount(output)} out`);
     }
-    return `**${WINDOWS[window].label}: AI Tokens**\n\n${parts.join(' • ')}`;
+    return `**${WINDOWS[window].label} AI Tokens:** ${parts.join(' • ')}`;
 }
 
 async function renderSinceToday(fetchEndpoint: EndpointFetch): Promise<string> {


### PR DESCRIPTION
Renders the AI Tokens facet on a single colon-form line (e.g. **Last 30 Days AI Tokens:** 4.2M in - 1.5M out) since it has no bar chart, and changes the bar-chart section headings from 'Last 30 Days: Languages' to 'Last 30 Days Languages:' for consistency with the other colon-form text stats. Applies to Languages, Editors, Categories, AI Cost, and AI Tokens across all windows.