### PR TITLE
fix(wakatime): inline total into AI cost heading

### DIFF
--- a/src/plugins/wakatime/index.ts
+++ b/src/plugins/wakatime/index.ts
@@ -358,7 +358,7 @@ async function renderAiCost(window: WindowKey, fetchEndpoint: EndpointFetch, top
     if (total === undefined || total <= 0) {
         return '';
     }
-    const header = `**${WINDOWS[window].label} AI Cost:**\n\n**Total:** $${total.toFixed(2)}`;
+    const header = `**${WINDOWS[window].label} AI Cost:** $${total.toFixed(2)} total`;
     const models = (data?.ai_model_breakdown ?? [])
         .filter((model): model is WakaTimeAiModel & { name: string; cost: number } =>
             typeof model.name === 'string' && typeof model.cost === 'number' && model.cost > 0)


### PR DESCRIPTION
Change renderAiCost from a two-line header (label then separate **Total:** line) to a single inline heading: **<label> AI Cost:** \.XX total, followed by the per-model bars. Consistent with the other colon-form one-liners.